### PR TITLE
Removes unnecessary commas at end of KV pair of objects

### DIFF
--- a/lib/Map.js
+++ b/lib/Map.js
@@ -87,7 +87,7 @@ MapSpec = {
   getInitialState:function () {
     return {
       /* [null, false, true] => ["init", "api loaded", "done"] */
-      _initialized: null,
+      _initialized: null
     };
   },
 
@@ -102,7 +102,7 @@ MapSpec = {
   componentWillReceiveProps:function (nextProps, nextContext) {
     if (null == this.state._initialized && nextContext.getApi()) {
       this.setState({
-        _initialized: false,
+        _initialized: false
       });
     }
   },

--- a/lib/mixins/EventBindingMixin.js
+++ b/lib/mixins/EventBindingMixin.js
@@ -22,6 +22,6 @@ module.exports = function (EVENT_MAP) {
         return;
       }
       _event_handles.map(event.removeListener, event);
-    },
+    }
   };
 };

--- a/src/Map.js
+++ b/src/Map.js
@@ -87,7 +87,7 @@ MapSpec = {
   getInitialState () {
     return {
       /* [null, false, true] => ["init", "api loaded", "done"] */
-      _initialized: null,
+      _initialized: null
     };
   },
 
@@ -102,7 +102,7 @@ MapSpec = {
   componentWillReceiveProps (nextProps, nextContext) {
     if (null == this.state._initialized && nextContext.getApi()) {
       this.setState({
-        _initialized: false,
+        _initialized: false
       });
     }
   },

--- a/src/mixins/EventBindingMixin.js
+++ b/src/mixins/EventBindingMixin.js
@@ -22,6 +22,6 @@ module.exports = function (EVENT_MAP) {
         return;
       }
       _event_handles.map(event.removeListener, event);
-    },
+    }
   };
 };


### PR DESCRIPTION
Just some general syntax clean up - removes commas at final key value pair for a few objects (breaks in IE9).