### PR TITLE
Marker animation fix

### DIFF
--- a/examples/gh-pages/scripts/components/GettingStarted.js
+++ b/examples/gh-pages/scripts/components/GettingStarted.js
@@ -17,6 +17,7 @@ class GettingStarted extends React.Component {
           lng: 121.52067570000001,
         },
         key: "Taiwan",
+        animation: 2
       }],
     };
   }
@@ -31,6 +32,7 @@ class GettingStarted extends React.Component {
       $push: [
         {
           position: event.latLng,
+          animation: 2,
           key: Date.now(),// Add a key property for: http://fb.me/react-warning-keys
         },
       ],
@@ -88,6 +90,7 @@ class GettingStarted extends React.Component {
         <Marker
           position={marker.position}
           key={marker.key}
+          animation={marker.animation}
           onRightclick={this._handle_marker_rightclick.bind(this, index)} />
       );
     }

--- a/src/internals/SimpleChildComponent.js
+++ b/src/internals/SimpleChildComponent.js
@@ -29,8 +29,9 @@ class SimpleChildComponent extends EventComponent {
 
     if (instance) {
       if (googleMapsConfig.map === instance.getMap()) {
-        // prevent it not to be removed first then be added later
+        // Set map and animation props only on the first run:
         delete googleMapsConfig.map;
+        delete googleMapsConfig.animation;
       }
       instance.setOptions(googleMapsConfig);
     } else {


### PR DESCRIPTION
Currently a markers animation runs on every state change, this patch makes sure to only set the animation on the initial run. 