### PR TITLE
feat(Declarative Bounds) specify map bounds via props

### DIFF
--- a/lib/GoogleMaps.js
+++ b/lib/GoogleMaps.js
@@ -26,9 +26,13 @@ var _internalsEventComponent = require("./internals/EventComponent");
 
 var _internalsEventComponent2 = _interopRequireDefault(_internalsEventComponent);
 
+/*eslint-disable no-unused-vars */
+
 var _internalsVirtualContainer = require("./internals/VirtualContainer");
 
 var _internalsVirtualContainer2 = _interopRequireDefault(_internalsVirtualContainer);
+
+/*eslint-enable no-unused-vars */
 
 var _internalsExposeGetters = require("./internals/exposeGetters");
 
@@ -107,14 +111,20 @@ var GoogleMaps = (function (_EventComponent) {
         return;
       }
       // googleMapsApi can be async loaded
+      /*eslint-disable no-unused-vars */
       var containerProps = props.containerProps;
       var googleMapsApi = props.googleMapsApi;
-      var key = props.key;
-      var ref = props.ref;
+      var bounds = props.bounds;
 
-      var googleMapsConfig = _objectWithoutProperties(props, ["containerProps", "googleMapsApi", "key", "ref"]);
+      var googleMapsConfig = _objectWithoutProperties(props, ["containerProps", "googleMapsApi", "bounds"]);
 
+      /*eslint-enable no-unused-vars */
       var instance = this.state.instance;
+
+      if (bounds) {
+        delete googleMapsConfig.zoom;
+        delete googleMapsConfig.center;
+      }
 
       if (instance) {
         instance.setOptions(googleMapsConfig);
@@ -125,6 +135,11 @@ var GoogleMaps = (function (_EventComponent) {
 
         this.setState({ instance: instance });
       }
+
+      if (bounds) {
+        instance.fitBounds(bounds);
+      }
+
       return instance;
     }
   }, {
@@ -178,7 +193,9 @@ var GoogleMaps = (function (_EventComponent) {
 })(_internalsEventComponent2["default"]);
 
 GoogleMaps.propTypes = _extends({}, _internalsEventComponent2["default"].propTypes, {
-  containerProps: PropTypes.object.isRequired });
+  containerProps: PropTypes.object.isRequired,
+  bounds: _react2["default"].PropTypes.object
+});
 
 GoogleMaps._registerEvents = (0, _internalsCreateRegisterEvents2["default"])("bounds_changed center_changed click dblclick drag dragend dragstart heading_changed idle maptypeid_changed mousemove mouseout mouseover projection_changed resize rightclick tilesloaded tilt_changed zoom_changed");
 

--- a/lib/addons/InfoBox.js
+++ b/lib/addons/InfoBox.js
@@ -54,11 +54,12 @@ var InfoBox = (function (_SimpleChildComponent) {
     key: "_createOrUpdateInstance",
     value: function _createOrUpdateInstance() {
       var props = this.props;
-      var key = props.key;
-      var ref = props.ref;
+      /*eslint-disable no-unused-vars */
+      var googleMapsApi = props.googleMapsApi;
 
-      var googleMapsConfig = _objectWithoutProperties(props, ["key", "ref"]);
+      var googleMapsConfig = _objectWithoutProperties(props, ["googleMapsApi"]);
 
+      /*eslint-enable no-unused-vars */
       var instance = this.state.instance;
 
       if (instance) {

--- a/lib/internals/EventComponent.js
+++ b/lib/internals/EventComponent.js
@@ -25,7 +25,7 @@ function noop() {}
 var EventComponent = (function (_React$Component) {
   /* Contract
    *  statics:
-   *    _registerEvents: 
+   *    _registerEvents:
    *  member:
    *    _createOrUpdateInstance
    */

--- a/lib/internals/SimpleChildComponent.js
+++ b/lib/internals/SimpleChildComponent.js
@@ -43,7 +43,7 @@ var PropTypes = _react2["default"].PropTypes;
 var SimpleChildComponent = (function (_EventComponent) {
   /* Contract
    *  statics:
-   *    _GoogleMapsClassName: 
+   *    _GoogleMapsClassName:
    *  state:
    *    instance
    */
@@ -70,10 +70,8 @@ var SimpleChildComponent = (function (_EventComponent) {
         return;
       }
       var googleMapsApi = props.googleMapsApi;
-      var key = props.key;
-      var ref = props.ref;
 
-      var googleMapsConfig = _objectWithoutProperties(props, ["googleMapsApi", "key", "ref"]);
+      var googleMapsConfig = _objectWithoutProperties(props, ["googleMapsApi"]);
 
       var instance = this.state.instance;
 
@@ -110,8 +108,6 @@ var SimpleChildComponent = (function (_EventComponent) {
   }, {
     key: "render",
     value: function render() {
-      var props = this.props;
-
       return _react2["default"].createElement("noscript", null);
     }
   }]);

--- a/lib/internals/VirtualContainer.js
+++ b/lib/internals/VirtualContainer.js
@@ -16,10 +16,6 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _EventComponent = require("./EventComponent");
-
-var _EventComponent2 = _interopRequireDefault(_EventComponent);
-
 var PropTypes = _react2["default"].PropTypes;
 
 var VirtualContainer = (function (_React$Component) {

--- a/lib/internals/exposeGetters.js
+++ b/lib/internals/exposeGetters.js
@@ -9,7 +9,7 @@ function exposeGetters(component, prototype, instance) {
       component[key] = instance[key].bind(instance);
     }
   }
-};
+}
 
 exports["default"] = exposeGetters;
 module.exports = exports["default"];

--- a/src/GoogleMaps.js
+++ b/src/GoogleMaps.js
@@ -55,9 +55,14 @@ class GoogleMaps extends EventComponent {
     }
     // googleMapsApi can be async loaded
     /*eslint-disable no-unused-vars */
-    const {containerProps, googleMapsApi, ...googleMapsConfig} = props;
+    const {containerProps, googleMapsApi, bounds, ...googleMapsConfig} = props;
     /*eslint-enable no-unused-vars */
     var {instance} = this.state;
+
+    if (bounds) {
+      delete googleMapsConfig.zoom;
+      delete googleMapsConfig.center;
+    }
 
     if (instance) {
       instance.setOptions(googleMapsConfig);
@@ -71,6 +76,11 @@ class GoogleMaps extends EventComponent {
 
       this.setState({instance});
     }
+
+    if (bounds) {
+      instance.fitBounds(bounds);
+    }
+
     return instance;
   }
 
@@ -120,6 +130,7 @@ class GoogleMaps extends EventComponent {
 GoogleMaps.propTypes = {
   ...EventComponent.propTypes,
   containerProps: PropTypes.object.isRequired,
+  bounds: React.PropTypes.object
 };
 
 GoogleMaps._registerEvents = createRegisterEvents(


### PR DESCRIPTION
This adds support for specifying the map bounds via props. This allows you to use the GoogleMaps component in a standard declarative way, instead of interacting with the map instance.