### PR TITLE
feat(InfoWindowReactChild): allow React elements as content for InfoWindow and InfoBox (which can be styled completely, unlike InfoWindow)

### DIFF
--- a/examples/gh-pages/scripts/components/basics/StyledMap.js
+++ b/examples/gh-pages/scripts/components/basics/StyledMap.js
@@ -4,18 +4,15 @@ import InfoBox from "react-google-maps/addons/InfoBox";
 
 class StyledMap extends React.Component {
 
+  _test_component_click(e) {
+    console.log("clicked InfoBox");
+  }
+
   render () {
     const {props, state} = this,
           {googleMapsApi, mapStyles, ...otherProps} = props;
     const myLatLng = new google.maps.LatLng(25.03, 121.6);
 
-    const InfoBoxContent = `
-      <div style="background-color:yellow; opacity:0.75;">
-        <div style="font-size: 16px; font-color:#08233B">
-          Taipei
-        </div>
-      </div>
-    `;
     return (
       <GoogleMaps containerProps={{
           ...otherProps,
@@ -30,7 +27,13 @@ class StyledMap extends React.Component {
         <InfoBox
           closeBoxURL=""
           position={myLatLng}
-          content={InfoBoxContent}/>
+          enableEventPropagation={true}>
+            <div style={{backgroundColor: 'yellow', opacity: '0.75'}} onClick={this._test_component_click}>
+              <div style={{fontSize: 16, fontColor: '#08233B'}}>
+                Taipei
+              </div>
+            </div>
+        </InfoBox>
       </GoogleMaps>
     );
   }

--- a/examples/gh-pages/scripts/components/events/ClosureListeners.js
+++ b/examples/gh-pages/scripts/components/events/ClosureListeners.js
@@ -49,6 +49,10 @@ class ClosureListeners extends React.Component {
     this.setState(this.state);
   }
 
+  _handle_infowindow_click () {
+    console.log('clicked InfoWindow');
+  }
+
   render () {
     const {props, state} = this,
           {googleMapsApi, ...otherProps} = props;
@@ -81,7 +85,9 @@ class ClosureListeners extends React.Component {
 
     function renderInfoWindow (marker, index) {
       var ref = `marker_${index}`;
-      return marker.showInfo ? <InfoWindow key={`${ref}_info_window`} owner={ref} content={marker.content} onCloseclick={this._handle_closeclick.bind(this, marker)} /> : null;
+      return marker.showInfo ? <InfoWindow key={`${ref}_info_window`} owner={ref} onCloseclick={this._handle_closeclick.bind(this, marker)}>
+          <div onClick={this._handle_infowindow_click} className="own-css-class" wrapperClassName="wrapper-css-class"> {marker.content} </div>
+        </InfoWindow> : null;
     }
   }
 

--- a/lib/addons/InfoBox.js
+++ b/lib/addons/InfoBox.js
@@ -70,7 +70,7 @@ var InfoBox = (function (_SimpleChildComponent) {
         // As a result, we import "google-maps-infobox" here to prevent an error on
         // a isomorphic server.
         var GoogleMapsInfobox = require("google-maps-infobox");
-        instance = new GoogleMapsInfobox(googleMapsConfig);
+        instance = new GoogleMapsInfobox(_get(Object.getPrototypeOf(InfoBox.prototype), "_handleMissingContent", this).call(this, googleMapsConfig));
         (0, _internalsExposeGetters2["default"])(this, GoogleMapsInfobox.prototype, instance);
         this.setState({ instance: instance });
         instance.open(this.props.map, this.props.anchor);

--- a/lib/internals/SimpleChildComponent.js
+++ b/lib/internals/SimpleChildComponent.js
@@ -81,7 +81,7 @@ var SimpleChildComponent = (function (_EventComponent) {
           delete googleMapsConfig.map;
           delete googleMapsConfig.animation;
         }
-        instance.setOptions(googleMapsConfig);
+        instance.setOptions(this._handleMissingContent(googleMapsConfig));
       } else {
         var googleMapsClassName = this.constructor._GoogleMapsClassName;
         if (!_objectPath2["default"].has(googleMapsApi, googleMapsClassName)) {
@@ -89,12 +89,29 @@ var SimpleChildComponent = (function (_EventComponent) {
           return;
         }
         var GoogleMapsClass = _objectPath2["default"].get(googleMapsApi, googleMapsClassName);
-        instance = new GoogleMapsClass(googleMapsConfig);
+        instance = new GoogleMapsClass(this._handleMissingContent(googleMapsConfig));
 
         (0, _exposeGetters2["default"])(this, GoogleMapsClass.prototype, instance);
         this.setState({ instance: instance });
       }
       return instance;
+    }
+  }, {
+    key: "_handleMissingContent",
+    value: function _handleMissingContent(config) {
+      var googleMapsClassName = this.constructor._GoogleMapsClassName;
+      if (googleMapsClassName != "InfoWindow" && googleMapsClassName != "InfoBox" || config.content) {
+        return config;
+      } else {
+        var detachedDiv = document.createElement("div"),
+            childComponent = _react2["default"].Children.only(this.props.children);
+        if (childComponent.props.wrapperClassName) {
+          detachedDiv.className = childComponent.props.wrapperClassName;
+        }
+        _react2["default"].render(childComponent, detachedDiv);
+        config.content = detachedDiv;
+        return config;
+      }
     }
   }, {
     key: "componentWillUnmount",

--- a/src/addons/InfoBox.js
+++ b/src/addons/InfoBox.js
@@ -26,7 +26,7 @@ class InfoBox extends SimpleChildComponent {
       // As a result, we import "google-maps-infobox" here to prevent an error on
       // a isomorphic server.
       const GoogleMapsInfobox = require("google-maps-infobox");
-      instance = new GoogleMapsInfobox(googleMapsConfig);
+      instance = new GoogleMapsInfobox(super._handleMissingContent(googleMapsConfig));
       exposeGetters(this, GoogleMapsInfobox.prototype, instance);
       this.setState({instance});
       instance.open(


### PR DESCRIPTION
@tomchentw implemented the API suggested by you  in https://github.com/tomchentw/react-google-maps/issues/25#issuecomment-105894253

The usage would be:
1. don't specify string content for the InfoWindow or InfoBox; instead, add a React child element to it
2. use the `wrapperClassName` for the child element in order to give that class name to the wrapper div (for CSS styling, etc)

## Important!

`InfoBox` won't allow any React events to bubble unless you give the `enableEventPropagation={true}` prop to it; see the whole API here: http://google-maps-utility-library-v3.googlecode.com/svn/trunk/infobox/docs/reference.html

The prop is disabled by default because it allows interaction with the map "through" the infobox when the above is set. Because React uses event delegation to trigger the handlers, couldn't find a way to cancel this effect. I'm considering using [react-native-listener](https://www.npmjs.com/package/react-native-listener) to solve this. **Update:** it works, though it's a bit hacky; I welcome suggestions

cc @MetalMatze