### PR TITLE
feat(GoogleMaps): specify map bounds via declarative props.bounds

### DIFF
--- a/src/GoogleMaps.js
+++ b/src/GoogleMaps.js
@@ -55,9 +55,14 @@ class GoogleMaps extends EventComponent {
     }
     // googleMapsApi can be async loaded
     /*eslint-disable no-unused-vars */
-    const {containerProps, googleMapsApi, ...googleMapsConfig} = props;
+    const {containerProps, googleMapsApi, bounds, ...googleMapsConfig} = props;
     /*eslint-enable no-unused-vars */
     var {instance} = this.state;
+
+    if (bounds) {
+      delete googleMapsConfig.zoom;
+      delete googleMapsConfig.center;
+    }
 
     if (instance) {
       instance.setOptions(googleMapsConfig);
@@ -71,6 +76,11 @@ class GoogleMaps extends EventComponent {
 
       this.setState({instance});
     }
+
+    if (bounds) {
+      instance.fitBounds(bounds);
+    }
+
     return instance;
   }
 
@@ -105,6 +115,7 @@ class GoogleMaps extends EventComponent {
 GoogleMaps.propTypes = {
   ...EventComponent.propTypes,
   containerProps: PropTypes.object.isRequired,
+  bounds: React.PropTypes.object
 };
 
 GoogleMaps._registerEvents = createRegisterEvents(


### PR DESCRIPTION
* Thanks to @petebrowne
* Original commit: a4b48a1307c4dcd2206c4b288521174f81d2bea7
* Closes #64