### PR TITLE
remove underscore in require

### DIFF
--- a/lib/DirectionsRenderer.js
+++ b/lib/DirectionsRenderer.js
@@ -24,12 +24,12 @@ var _react2 = _interopRequireDefault(_react);
 
 var _creatorsDirectionsRendererCreator = require("./creators/DirectionsRendererCreator");
 
+var _creatorsDirectionsRendererCreator2 = _interopRequireDefault(_creatorsDirectionsRendererCreator);
+
 /*
  * Original author: @alexishevia
  * Original PR: https://github.com/tomchentw/react-google-maps/pull/22
  */
-
-var _creatorsDirectionsRendererCreator2 = _interopRequireDefault(_creatorsDirectionsRendererCreator);
 
 var DirectionsRenderer = (function (_Component) {
   _inherits(DirectionsRenderer, _Component);

--- a/lib/DrawingManager.js
+++ b/lib/DrawingManager.js
@@ -24,12 +24,12 @@ var _react2 = _interopRequireDefault(_react);
 
 var _creatorsDrawingManagerCreator = require("./creators/DrawingManagerCreator");
 
+var _creatorsDrawingManagerCreator2 = _interopRequireDefault(_creatorsDrawingManagerCreator);
+
 /*
  * Original author: @idolize
  * Original PR: https://github.com/tomchentw/react-google-maps/pull/46
  */
-
-var _creatorsDrawingManagerCreator2 = _interopRequireDefault(_creatorsDrawingManagerCreator);
 
 var DrawingManager = (function (_Component) {
   _inherits(DrawingManager, _Component);

--- a/lib/GoogleMap.js
+++ b/lib/GoogleMap.js
@@ -129,18 +129,17 @@ var GoogleMap = (function (_Component) {
     value: function componentDidMount() {
       var domEl = (0, _react.findDOMNode)(this);
       var _props = this.props;
-
-      // TODO: support asynchronous load of google.maps API at this level.
-      //
-      // Create google.maps.Map instance so that dom is initialized before
-      // React's children creators.
-      //
       var containerTagName = _props.containerTagName;
       var containerProps = _props.containerProps;
       var children = _props.children;
 
       var mapProps = _objectWithoutProperties(_props, ["containerTagName", "containerProps", "children"]);
 
+      // TODO: support asynchronous load of google.maps API at this level.
+      //
+      // Create google.maps.Map instance so that dom is initialized before
+      // React's children creators.
+      //
       var map = _creatorsGoogleMapHolder2["default"]._createMap(domEl, mapProps);
       this.setState({ map: map });
     }

--- a/lib/OverlayView.js
+++ b/lib/OverlayView.js
@@ -24,12 +24,12 @@ var _react2 = _interopRequireDefault(_react);
 
 var _creatorsOverlayViewCreator = require("./creators/OverlayViewCreator");
 
+var _creatorsOverlayViewCreator2 = _interopRequireDefault(_creatorsOverlayViewCreator);
+
 /*
  * Original author: @petebrowne
  * Original PR: https://github.com/tomchentw/react-google-maps/pull/63
  */
-
-var _creatorsOverlayViewCreator2 = _interopRequireDefault(_creatorsOverlayViewCreator);
 
 var OverlayView = (function (_Component) {
   _inherits(OverlayView, _Component);

--- a/lib/Rectangle.js
+++ b/lib/Rectangle.js
@@ -22,14 +22,14 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _creators_RectangleCreator = require("./creators/_RectangleCreator");
+var _creatorsRectangleCreator = require("./creators/RectangleCreator");
+
+var _creatorsRectangleCreator2 = _interopRequireDefault(_creatorsRectangleCreator);
 
 /*
  * Original author: @alistairjcbrown
  * Original PR: https://github.com/tomchentw/react-google-maps/pull/80
  */
-
-var _creators_RectangleCreator2 = _interopRequireDefault(_creators_RectangleCreator);
 
 var Rectangle = (function (_Component) {
   _inherits(Rectangle, _Component);
@@ -81,7 +81,7 @@ var Rectangle = (function (_Component) {
 
       var rectangleProps = _objectWithoutProperties(_props, ["mapHolderRef"]);
 
-      var rectangle = _creators_RectangleCreator2["default"]._createRectangle(mapHolderRef, rectangleProps);
+      var rectangle = _creatorsRectangleCreator2["default"]._createRectangle(mapHolderRef, rectangleProps);
 
       this.setState({ rectangle: rectangle });
     }
@@ -90,7 +90,7 @@ var Rectangle = (function (_Component) {
     value: function render() {
       if (this.state.rectangle) {
         return _react2["default"].createElement(
-          _creators_RectangleCreator2["default"],
+          _creatorsRectangleCreator2["default"],
           _extends({ rectangle: this.state.rectangle }, this.props),
           this.props.children
         );
@@ -100,7 +100,7 @@ var Rectangle = (function (_Component) {
     }
   }], [{
     key: "propTypes",
-    value: _extends({}, _creators_RectangleCreator.rectangleDefaultPropTypes, _creators_RectangleCreator.rectangleControlledPropTypes, _creators_RectangleCreator.rectangleEventPropTypes),
+    value: _extends({}, _creatorsRectangleCreator.rectangleDefaultPropTypes, _creatorsRectangleCreator.rectangleControlledPropTypes, _creatorsRectangleCreator.rectangleEventPropTypes),
     enumerable: true
   }]);
 

--- a/lib/addons/InfoBox.js
+++ b/lib/addons/InfoBox.js
@@ -24,12 +24,12 @@ var _react2 = _interopRequireDefault(_react);
 
 var _addonsCreatorsInfoBoxCreator = require("./addonsCreators/InfoBoxCreator");
 
+var _addonsCreatorsInfoBoxCreator2 = _interopRequireDefault(_addonsCreatorsInfoBoxCreator);
+
 /*
  * Original author: @wuct
  * Original PR: https://github.com/tomchentw/react-google-maps/pull/54
  */
-
-var _addonsCreatorsInfoBoxCreator2 = _interopRequireDefault(_addonsCreatorsInfoBoxCreator);
 
 var InfoBox = (function (_Component) {
   _inherits(InfoBox, _Component);

--- a/src/Rectangle.js
+++ b/src/Rectangle.js
@@ -8,7 +8,7 @@ import {
   rectangleDefaultPropTypes,
   rectangleControlledPropTypes,
   rectangleEventPropTypes
-} from "./creators/_RectangleCreator";
+} from "./creators/RectangleCreator";
 
 /*
  * Original author: @alistairjcbrown


### PR DESCRIPTION
right now when you require the `GoogleMap` you get this error

`Uncaught Error: Cannot find module "./creators/_RectangleCreator"`

removing the underscore removes the issue.