### PR TITLE
Fix overlay view not rendering correctly

### DIFF
--- a/src/creators/OverlayViewCreator.js
+++ b/src/creators/OverlayViewCreator.js
@@ -34,6 +34,7 @@ export default class OverlayViewCreator extends Component {
       "mapPaneName",
       "getPixelPositionOffset",
       "children",
+      "position"
     ]));
 
     overlayView.onAdd = function () {


### PR DESCRIPTION
Hi!

I recently upgraded to the latest version of react-google-maps and my ```OverlayView```s stopped working. They would mysteriously cluster at the origin of the map:

![image](https://cloud.githubusercontent.com/assets/14410/9293964/aa8eba10-4435-11e5-8eca-f93114bbc1e8.png)

After adding the position property to the whitelist of component properties (although admittedly in the post-babel distribution code in my node_modules folder) they spring into life again:

![image](https://cloud.githubusercontent.com/assets/14410/9293965/b5124f38-4435-11e5-8d35-03de4e8973ed.png)

This was made a little trickier to debug because the ```_getPixelPosition``` method doesn't complain if it cannot get a projection or a position for the ```OverlayView```. It would probably be worth taking this change one step further and adding a warning if the ```if (projection && position) {``` condition does not match.

Cheers,
~ Si

