### PR TITLE
Fixes for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,20 @@ npm install
 npm start
 ```
 
-Then open [http://localhost:8080](http://localhost:8080).
+Then open [http://localhost:8080/webpack-dev-server/](http://localhost:8080/webpack-dev-server/).
+
+### With Windows
+
+Install `node@^0.12.4`. Then,
+
+```shell
+npm install
+cd examples/gh-pages
+npm install
+npm start-windows
+```
+
+Then open [http://localhost:8080/webpack-dev-server/](http://localhost:8080/webpack-dev-server/).
 
 
 ## Contributing

--- a/examples/gh-pages/package.json
+++ b/examples/gh-pages/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "rimraf ../../public/index.html ../../public/assets ../../tmp",
     "build": "npm run clean && NODE_ENV=production webpack -p",
+    "build-windows": "set NODE_ENV=production&& npm run clean && webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
     "docker_start": "npm run clean && webpack-dev-server -d --docker"

--- a/examples/gh-pages/package.json
+++ b/examples/gh-pages/package.json
@@ -2,7 +2,7 @@
   "name": "gh-pages",
   "version": "1.0.0",
   "scripts": {
-    "clean": "rm -rf ../../public/index.html ../../public/assets ../../tmp",
+    "clean": "rimraf ../../public/index.html ../../public/assets ../../tmp",
     "build": "npm run clean && NODE_ENV=production webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
@@ -21,7 +21,8 @@
     "sass-loader": "^1.0.1",
     "style-loader": "^0.12.2",
     "webpack": "^1.9.5",
-    "webpack-dev-server": "^1.8.2"
+    "webpack-dev-server": "^1.8.2",
+    "rimraf": "^2.4.3"
   },
   "dependencies": {
     "animate.css": "^3.2.5",

--- a/examples/gh-pages/package.json
+++ b/examples/gh-pages/package.json
@@ -7,6 +7,7 @@
     "build-windows": "set NODE_ENV=production&& npm run clean && webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
+    "start-windows": "npm run clean && webpack -d && webpack-dev-server -d",
     "docker_start": "npm run clean && webpack-dev-server -d --docker"
   },
   "devDependencies": {

--- a/examples/simplemap/package.json
+++ b/examples/simplemap/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "clean": "rimraf ../../public/index.html ../../public/assets ../../tmp",
     "build": "npm run clean && NODE_ENV=production webpack -p",
+    "build-windows": "set NODE_ENV=production&& npm run clean && webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
     "docker_start": "npm run clean && webpack-dev-server -d --docker"

--- a/examples/simplemap/package.json
+++ b/examples/simplemap/package.json
@@ -2,7 +2,7 @@
   "name": "simplemap",
   "version": "1.0.0",
   "scripts": {
-    "clean": "rm -rf ../../public/index.html ../../public/assets ../../tmp",
+    "clean": "rimraf ../../public/index.html ../../public/assets ../../tmp",
     "build": "npm run clean && NODE_ENV=production webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
@@ -21,7 +21,8 @@
     "sass-loader": "^1.0.1",
     "style-loader": "^0.12.2",
     "webpack": "^1.9.5",
-    "webpack-dev-server": "^1.8.2"
+    "webpack-dev-server": "^1.8.2",
+    "rimraf": "^2.4.3"
   },
   "dependencies": {
     "bootstrap-sass": "^3.3.4",

--- a/examples/simplemap/package.json
+++ b/examples/simplemap/package.json
@@ -7,6 +7,7 @@
     "build-windows": "set NODE_ENV=production&& npm run clean && webpack -p",
     "dev": "npm run clean && webpack -d",
     "start": "npm run clean && webpack-dev-server -d",
+    "start-windows": "npm run clean && webpack -d && webpack-dev-server -d",
     "docker_start": "npm run clean && webpack-dev-server -d --docker"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "build": "npm run lint && npm run clean && babel --stage=1 src --out-dir lib",
     "lint": "eslint src",
     "test": "npm run lint"
@@ -57,7 +57,8 @@
     "babel-eslint": "^4.0.5",
     "eslint": "^1.0.0",
     "eslint-plugin-react": "^3.2.0",
-    "tomchentw-npm-dev": "^3.0.0"
+    "tomchentw-npm-dev": "^3.0.0",
+    "rimraf": "^2.4.3"
   },
   "dependencies": {
     "google-maps-infobox": "^1.1.13",


### PR DESCRIPTION
As requested in #48 these changes fix running the examples on windows machines. 

* `npm run clean` now uses the module `rimraf` instead of `rm -rf`
* `npm run build-windows` was added as NODE_ENV is set differently ([more info](http://stackoverflow.com/questions/9249830/how-can-i-set-node-env-production-in-windows))
* `npm run start-windows` was added as I found that `webpack -d` needs to run first to generate files for `webpack-dev-server` to work properly