### PR TITLE
fix(Marker): allow null and undefined as children

### DIFF
--- a/src/creators/MarkerCreator.js
+++ b/src/creators/MarkerCreator.js
@@ -110,7 +110,7 @@ export default class MarkerCreator extends Component {
     if (0 < Children.count(children)) {
       return (
         <div>{Children.map(children, childElement =>
-          React.cloneElement(childElement, {
+          childElement && React.cloneElement(childElement, {
             mapHolderRef,
             anchorHolderRef: this,
           })


### PR DESCRIPTION
This is useful if you have code like the following:

```js
<Marker {...props}>
  { showInfo &&
    <InfoWindow content="Some Info" />
  }
</Marker>
```

Right now, this will throw an `Error` about being unable to read `props` of `undefined`, so you have to use the following workaround (not ideal):

```js
// workaround:
<Marker {...props}>
  { showInfo ?
    <InfoWindow content="Some Info" />
    : <noscript />
  }
</Marker>
```

With this change, the workaround is no longer needed and the first example works as expected :smile: 