### PR TITLE
Use ReactDOM for unmountComponentAtNode.

### DIFF
--- a/src/creators/OverlayViewCreator.js
+++ b/src/creators/OverlayViewCreator.js
@@ -4,6 +4,7 @@ import {
   Component,
   Children,
 } from "react";
+import ReactDOM from "react-dom";
 import {default as invariant} from "invariant";
 
 import {default as defaultPropsCreator} from "../utils/defaultPropsCreator";
@@ -53,7 +54,7 @@ export default class OverlayViewCreator extends Component {
     };
 
     overlayView.onRemove = function () {
-      React.unmountComponentAtNode(this._containerElement);
+      ReactDOM.unmountComponentAtNode(this._containerElement);
       this._unmountContainerFromPane();
       this._containerElement = null;
     };


### PR DESCRIPTION
Fixes this warning:

    React.unmountComponentAtNode is deprecated. Please use ReactDOM.unmountComponentAtNode from require('react-dom') instead.