### PR TITLE
expose Public API's to ScriptjsGoogleMap

### DIFF
--- a/lib/async/ScriptjsGoogleMap.js
+++ b/lib/async/ScriptjsGoogleMap.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
@@ -48,6 +50,93 @@ var ScriptjsGoogleMap = (function (_Component) {
   }
 
   _createClass(ScriptjsGoogleMap, [{
+    key: "getBounds",
+
+    // Public APIs
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+    //
+    // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return it.match(/^get/) && !it.match(/Map$/); })
+    value: function getBounds() {
+      return this.refs.map.getBounds();
+    }
+  }, {
+    key: "getCenter",
+    value: function getCenter() {
+      return this.refs.map.getCenter();
+    }
+  }, {
+    key: "getDiv",
+    value: function getDiv() {
+      return this.refs.map.getDiv();
+    }
+  }, {
+    key: "getHeading",
+    value: function getHeading() {
+      return this.refs.map.getHeading();
+    }
+  }, {
+    key: "getMapTypeId",
+    value: function getMapTypeId() {
+      return this.refs.map.getMapTypeId();
+    }
+  }, {
+    key: "getProjection",
+    value: function getProjection() {
+      return this.refs.map.getProjection();
+    }
+  }, {
+    key: "getStreetView",
+    value: function getStreetView() {
+      return this.refs.map.getStreetView();
+    }
+  }, {
+    key: "getTilt",
+    value: function getTilt() {
+      return this.refs.map.getTilt();
+    }
+  }, {
+    key: "getZoom",
+    value: function getZoom() {
+      return this.refs.map.getZoom();
+    }
+
+    // END - Public APIs
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+    //
+    // Public APIs - Use this carefully
+    // See discussion in https://github.com/tomchentw/react-google-maps/issues/62
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+    //
+    // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return !it.match(/^get/) && !it.match(/^set/) && !it.match(/Map$/); })
+  }, {
+    key: "fitBounds",
+    value: function fitBounds(bounds) {
+      return this.refs.map.fitBounds(bounds);
+    }
+  }, {
+    key: "panBy",
+    value: function panBy(x, y) {
+      return this.refs.map.panBy(x, y);
+    }
+  }, {
+    key: "panTo",
+    value: function panTo(latLng) {
+      return this.refs.map.panTo(latLng);
+    }
+  }, {
+    key: "panToBounds",
+    value: function panToBounds(latLngBounds) {
+      return this.refs.map.panToBounds(latLngBounds);
+    }
+
+    // END - Public APIs - Use this carefully
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+
+  }, {
     key: "componentWillMount",
     value: function componentWillMount() {
       var _this = this;
@@ -80,7 +169,10 @@ var ScriptjsGoogleMap = (function (_Component) {
         return _this2.props[key] !== nextProps[key];
       });
 
-      (0, _warning2["default"])(0 === changedKeys.length, "ScriptjsGoogleMap doesn't support mutating props after initial render. Changed props: %s", "[" + changedKeys.join(", ") + "]");
+      // I'm disabling the warning because what if I pass an empty object into the query prop?
+      // This doesn't support object equality
+      //
+      // warning(0 === changedKeys.length, `ScriptjsGoogleMap doesn't support mutating props after initial render. Changed props: %s`, `[${ changedKeys.join(", ") }]`);
     }
   }, {
     key: "render",
@@ -95,7 +187,7 @@ var ScriptjsGoogleMap = (function (_Component) {
 
         var restProps = _objectWithoutProperties(_props2, ["protocol", "hostname", "port", "pathname", "query"]);
 
-        return _react2["default"].createElement(_index.GoogleMap, restProps);
+        return _react2["default"].createElement(_index.GoogleMap, _extends({}, restProps, { ref: "map" }));
       } else {
         return this.props.loadingElement;
       }

--- a/src/async/ScriptjsGoogleMap.js
+++ b/src/async/ScriptjsGoogleMap.js
@@ -33,6 +33,49 @@ export default class ScriptjsGoogleMap extends Component {
     loadingElement: PropTypes.node,
   }
 
+  // Public APIs
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+  //
+  // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return it.match(/^get/) && !it.match(/Map$/); })
+  getBounds () { return this.refs.map.getBounds(); }
+
+  getCenter () { return this.refs.map.getCenter(); }
+
+  getDiv () { return this.refs.map.getDiv(); }
+
+  getHeading () { return this.refs.map.getHeading(); }
+
+  getMapTypeId () { return this.refs.map.getMapTypeId(); }
+
+  getProjection () { return this.refs.map.getProjection(); }
+
+  getStreetView () { return this.refs.map.getStreetView(); }
+
+  getTilt () { return this.refs.map.getTilt(); }
+
+  getZoom () { return this.refs.map.getZoom(); }
+  // END - Public APIs
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+  //
+  // Public APIs - Use this carefully
+  // See discussion in https://github.com/tomchentw/react-google-maps/issues/62
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+  //
+  // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return !it.match(/^get/) && !it.match(/^set/) && !it.match(/Map$/); })
+  fitBounds (bounds) { return this.refs.map.fitBounds(bounds); }
+
+  panBy (x, y) { return this.refs.map.panBy(x, y); }
+
+  panTo (latLng) { return this.refs.map.panTo(latLng); }
+
+  panToBounds (latLngBounds) { return this.refs.map.panToBounds(latLngBounds); }
+  // END - Public APIs - Use this carefully
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
+
   state = {
     isLoaded: false,
   }
@@ -52,14 +95,17 @@ export default class ScriptjsGoogleMap extends Component {
     const changedKeys = Object.keys(ScriptjsGoogleMap.propTypes)
       .filter(key => this.props[key] !== nextProps[key]);
 
-    warning(0 === changedKeys.length, `ScriptjsGoogleMap doesn't support mutating props after initial render. Changed props: %s`, `[${ changedKeys.join(", ") }]`);
+    // I'm disabling the warning because what if I pass an empty object into the query prop?
+    // This doesn't support object equality
+    //
+    // warning(0 === changedKeys.length, `ScriptjsGoogleMap doesn't support mutating props after initial render. Changed props: %s`, `[${ changedKeys.join(", ") }]`);
   }
 
   render () {
     if (this.state.isLoaded) {
       const {protocol, hostname, port, pathname, query, ...restProps} = this.props;
       return (
-        <GoogleMap {...restProps} />
+        <GoogleMap {...restProps} ref="map" />
       );
     } else {
       return this.props.loadingElement;


### PR DESCRIPTION
I'd love to hear your thoughts on this. We're using the async ScriptjsGoogleMap implementation and we need access to the Public Api's specifically fitBounds. 

Also the warning doesn't support object equality, so I decided to hide it:
```
warning(0 === changedKeys.length, `ScriptjsGoogleMap doesn't support mutating props after initial render. Changed props: %s`, `[${ changedKeys.join(", ") }]`);`
```