### PR TITLE
Better examples

### DIFF
--- a/examples/gh-pages/package.json
+++ b/examples/gh-pages/package.json
@@ -46,6 +46,7 @@
     "react-addons-update": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-github-fork-ribbon": "^0.4.2",
+    "react-google-maps": "^4.4.0",
     "react-icons": "^0.1.4",
     "react-prism": "^3.0.0",
     "react-pure-render": "^1.0.2",

--- a/examples/gh-pages/scripts/components/AsyncGettingStarted.js
+++ b/examples/gh-pages/scripts/components/AsyncGettingStarted.js
@@ -30,7 +30,7 @@ export default class AsyncGettingStarted extends Component {
    * This is called when you click on the map.
    * Go and try click now.
    */
-  _handle_map_click (event) {
+  handleMapClick (event) {
     var {markers} = this.state;
     markers = update(markers, {
       $push: [
@@ -51,7 +51,7 @@ export default class AsyncGettingStarted extends Component {
     }
   }
 
-  _handle_marker_rightclick (index, event) {
+  handleMarkerRightclick (index, event) {
     /*
      * All you modify is data, and the view is driven by data.
      * This is so called data-driven-development. (And yes, it's now in
@@ -99,12 +99,12 @@ export default class AsyncGettingStarted extends Component {
         ref="map"
         defaultZoom={3}
         defaultCenter={{lat: -25.363882, lng: 131.044922}}
-        onClick={::this._handle_map_click}>
+        onClick={::this.handleMapClick}>
         {this.state.markers.map((marker, index) => {
           return (
             <Marker
               {...marker}
-              onRightclick={this._handle_marker_rightclick.bind(this, index)} />
+              onRightclick={this.handleMarkerRightclick.bind(this, index)} />
           );
         })}
       </ScriptjsGoogleMap>

--- a/examples/gh-pages/scripts/components/AsyncGettingStarted.js
+++ b/examples/gh-pages/scripts/components/AsyncGettingStarted.js
@@ -2,8 +2,8 @@ import {default as React, Component} from "react";
 import {default as update} from "react-addons-update";
 import {default as FaSpinner} from "react-icons/lib/fa/spinner";
 
-import {default as ScriptjsGoogleMap} from "../../../../src/async/ScriptjsGoogleMap";
-import {default as Marker} from "../../../../src/Marker";
+import {default as ScriptjsGoogleMap} from "react-google-maps/lib/async/ScriptjsGoogleMap";
+import {Marker} from "react-google-maps";
 
 /*
  * This is the modify version of:

--- a/examples/gh-pages/scripts/components/GeojsonToComponents.js
+++ b/examples/gh-pages/scripts/components/GeojsonToComponents.js
@@ -44,30 +44,30 @@ export default class GeojsonToComponents extends Component {
       0: {
         ref: "map",
         style: {height: "100%"},
-        onClick: ::this._handle_map_click,
-        onZoomChanged: ::this._handle_map_zoom_changed,
+        onClick: ::this.handleMapClick,
+        onZoomChanged: ::this.handleMapZoomChanged,
       },
       1: {
         ref: "centerMarker",
         visible: true,
         draggable: true,
-        onDragend: ::this._handle_marker_dragend,
-        onClick: ::this._handle_marker_click,
+        onDragend: ::this.handleMarkerDragend,
+        onClick: ::this.handleMarkerClick,
         child: {
           content: "Bermuda Triangle",
           owner: "centerMarker",
         },
       },
       3: {
-        onRightclick: ::this._handle_polygon_rightclick,
+        onRightclick: ::this.handlePolygonRightclick,
       },
     },
   }
 
-  _handle_map_click () {
+  handleMapClick () {
   }
 
-  _handle_map_zoom_changed () {
+  handleMapZoomChanged () {
     this.setState(update(this.state, {
       geoStateBy: {
         0: {
@@ -84,7 +84,7 @@ export default class GeojsonToComponents extends Component {
     }));
   }
 
-  _handle_marker_click () {
+  handleMarkerClick () {
     this.setState(update(this.state, {
       geoStateBy: {
         0: {
@@ -96,7 +96,7 @@ export default class GeojsonToComponents extends Component {
     }));
   }
 
-  _handle_polygon_rightclick () {
+  handlePolygonRightclick () {
     this.setState(update(this.state, {
       geoStateBy: {
         1: {
@@ -108,7 +108,7 @@ export default class GeojsonToComponents extends Component {
     }));
   }
 
-  _handle_marker_dragend ({latLng}) {
+  handleMarkerDragend ({latLng}) {
     const marker = this.state.geoJson.features[1],
           originalCoordinates = marker.properties.originalCoordinates || marker.geometry.coordinates,
           newCoordinates = [latLng.lng(), latLng.lat()];

--- a/examples/gh-pages/scripts/components/GeojsonToComponents.js
+++ b/examples/gh-pages/scripts/components/GeojsonToComponents.js
@@ -1,11 +1,7 @@
 import {default as React, Component} from "react";
 import {default as update} from "react-addons-update";
 
-import {default as GoogleMap} from "../../../../src/GoogleMap";
-import {default as Marker} from "../../../../src/Marker";
-import {default as Polyline} from "../../../../src/Polyline";
-import {default as Polygon} from "../../../../src/Polygon";
-import {default as InfoWindow} from "../../../../src/InfoWindow";
+import {GoogleMap, Marker, Polyline, Polygon, InfoWindow} from "react-google-maps";
 
 function geometryToComponentWithLatLng (geometry) {
   var typeFromThis = Array.isArray(geometry),

--- a/examples/gh-pages/scripts/components/GettingStarted.js
+++ b/examples/gh-pages/scripts/components/GettingStarted.js
@@ -1,8 +1,7 @@
 import {default as React, Component} from "react";
 import {default as update} from "react-addons-update";
 
-import {default as GoogleMap} from "../../../../src/GoogleMap";
-import {default as Marker} from "../../../../src/Marker";
+import {GoogleMap, Marker} from "react-google-maps";
 
 /*
  * This is the modify version of:

--- a/examples/gh-pages/scripts/components/GettingStarted.js
+++ b/examples/gh-pages/scripts/components/GettingStarted.js
@@ -26,7 +26,7 @@ export default class GettingStarted extends Component {
    * This is called when you click on the map.
    * Go and try click now.
    */
-  _handle_map_click (event) {
+  handleMapClick (event) {
     var {markers} = this.state;
     markers = update(markers, {
       $push: [
@@ -47,7 +47,7 @@ export default class GettingStarted extends Component {
     }
   }
 
-  _handle_marker_rightclick (index, event) {
+  handleMarkerRightclick (index, event) {
     /*
      * All you modify is data, and the view is driven by data.
      * This is so called data-driven-development. (And yes, it's now in
@@ -73,12 +73,12 @@ export default class GettingStarted extends Component {
         ref="map"
         defaultZoom={3}
         defaultCenter={{lat: -25.363882, lng: 131.044922}}
-        onClick={::this._handle_map_click}>
+        onClick={::this.handleMapClick}>
         {this.state.markers.map((marker, index) => {
           return (
             <Marker
               {...marker}
-              onRightclick={this._handle_marker_rightclick.bind(this, index)} />
+              onRightclick={this.handleMarkerRightclick.bind(this, index)} />
           );
         })}
       </GoogleMap>

--- a/examples/gh-pages/scripts/components/basics/Directions.js
+++ b/examples/gh-pages/scripts/components/basics/Directions.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as DirectionsRenderer} from "../../../../../src/DirectionsRenderer";
+import {GoogleMap, DirectionsRenderer} from "react-google-maps";
 
 /*
  * Add <script src="https://maps.googleapis.com/maps/api/js"></script> to your HTML to provide google.maps reference

--- a/examples/gh-pages/scripts/components/basics/Geolocation.js
+++ b/examples/gh-pages/scripts/components/basics/Geolocation.js
@@ -6,9 +6,7 @@ import {
 
 import {default as raf} from "raf";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as Circle} from "../../../../../src/Circle";
-import {default as InfoWindow} from "../../../../../src/InfoWindow";
+import {GoogleMap, Circle, InfoWindow} from "react-google-maps";
 
 const geolocation = (
   canUseDOM && navigator.geolocation || {

--- a/examples/gh-pages/scripts/components/basics/MarkerClusterer.js
+++ b/examples/gh-pages/scripts/components/basics/MarkerClusterer.js
@@ -1,9 +1,8 @@
-import { default as React, Component } from "react";
-import { default as fetch } from "isomorphic-fetch";
+import {default as React, Component} from "react";
+import {default as fetch} from "isomorphic-fetch";
 
-import { default as GoogleMap } from "../../../../../src/GoogleMap";
-import { default as Marker } from "../../../../../src/Marker";
-import { default as MarkerClusterer } from "../../../../../src/addons/MarkerClusterer";
+import {GoogleMap, Marker} from "react-google-maps";
+import {default as MarkerClusterer} from "react-google-maps/lib/addons/MarkerClusterer";
 
 export default class MarkerClustererExample extends Component {
   state = {

--- a/examples/gh-pages/scripts/components/basics/OverlayView.js
+++ b/examples/gh-pages/scripts/components/basics/OverlayView.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as OverlayView} from "../../../../../src/OverlayView";
+import {GoogleMap, OverlayView} from "react-google-maps";
 
 const STYLES = {
   mapContainer: {

--- a/examples/gh-pages/scripts/components/basics/SimpleMap.js
+++ b/examples/gh-pages/scripts/components/basics/SimpleMap.js
@@ -1,6 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
+import {GoogleMap} from "react-google-maps";
 /*
  * Sample From: https://developers.google.com/maps/documentation/javascript/examples/map-simple
  *

--- a/examples/gh-pages/scripts/components/basics/StyledMap.js
+++ b/examples/gh-pages/scripts/components/basics/StyledMap.js
@@ -1,7 +1,7 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as InfoBox} from "../../../../../src/addons/InfoBox";
+import {GoogleMap} from "react-google-maps";
+import {default as InfoBox} from "react-google-maps/lib/addons/InfoBox";
 
 /*
  * Add <script src="https://maps.googleapis.com/maps/api/js"></script> to your HTML to provide google.maps reference

--- a/examples/gh-pages/scripts/components/drawing/DrawingTools.js
+++ b/examples/gh-pages/scripts/components/drawing/DrawingTools.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as DrawingManager} from "../../../../../src/DrawingManager";
+import {GoogleMap, DrawingManager} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/drawing-tools

--- a/examples/gh-pages/scripts/components/events/AccessingArguments.js
+++ b/examples/gh-pages/scripts/components/events/AccessingArguments.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as Marker} from "../../../../../src/Marker";
+import {GoogleMap, Marker} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/event-arguments

--- a/examples/gh-pages/scripts/components/events/AccessingArguments.js
+++ b/examples/gh-pages/scripts/components/events/AccessingArguments.js
@@ -14,7 +14,7 @@ export default class AccessingArguments extends Component {
     center: new google.maps.LatLng(-25.363882, 131.044922),
   }
 
-  _handle_map_click (event) {
+  handleMapClick (event) {
     const {markers} = this.state;
     markers.push({
       position: event.latLng
@@ -38,7 +38,7 @@ export default class AccessingArguments extends Component {
         ref="map"
         defaultZoom={4}
         center={center}
-        onClick={::this._handle_map_click}>
+        onClick={::this.handleMapClick}>
         {markers.map((marker, index) =>
           <Marker position={marker.position} key={index} />
         )}

--- a/examples/gh-pages/scripts/components/events/ClosureListeners.js
+++ b/examples/gh-pages/scripts/components/events/ClosureListeners.js
@@ -1,8 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as Marker} from "../../../../../src/Marker";
-import {default as InfoWindow} from "../../../../../src/InfoWindow";
+import {GoogleMap, Marker, InfoWindow} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/event-closure

--- a/examples/gh-pages/scripts/components/events/ClosureListeners.js
+++ b/examples/gh-pages/scripts/components/events/ClosureListeners.js
@@ -38,30 +38,30 @@ export default class ClosureListeners extends Component {
     });
   }
 
-  _handle_marker_click (marker) {
+  handleMarkerClick (marker) {
     marker.showInfo = true;
     this.setState(this.state);
   }
 
-  _handle_closeclick (marker) {
+  handleCloseclick (marker) {
     marker.showInfo = false;
     this.setState(this.state);
   }
 
-  _render_InfoWindow (ref, marker) {
+  renderInfoWindow (ref, marker) {
     if (Math.random() > 0.5) {
       // Normal version: Pass string as content
       return (
         <InfoWindow key={`${ref}_info_window`}
           content={marker.content}
-          onCloseclick={this._handle_closeclick.bind(this, marker)}
+          onCloseclick={this.handleCloseclick.bind(this, marker)}
         />
       )
     } else {
       // "react-google-maps" extended version: Pass ReactElement as content
       return (
         <InfoWindow key={`${ref}_info_window`}
-          onCloseclick={this._handle_closeclick.bind(this, marker)}
+          onCloseclick={this.handleCloseclick.bind(this, marker)}
         >
           <div>
             <strong>{marker.content}</strong>
@@ -92,8 +92,8 @@ export default class ClosureListeners extends Component {
             <Marker key={ref} ref={ref}
               position={marker.position}
               title={(index+1).toString()}
-              onClick={this._handle_marker_click.bind(this, marker)}>
-              {marker.showInfo ? this._render_InfoWindow(ref, marker) : null}
+              onClick={this.handleMarkerClick.bind(this, marker)}>
+              {marker.showInfo ? this.renderInfoWindow(ref, marker) : null}
             </Marker>
           );
         })}

--- a/examples/gh-pages/scripts/components/events/GettingProperties.js
+++ b/examples/gh-pages/scripts/components/events/GettingProperties.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as InfoWindow} from "../../../../../src/InfoWindow";
+import {GoogleMap, InfoWindow} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/event-properties

--- a/examples/gh-pages/scripts/components/events/GettingProperties.js
+++ b/examples/gh-pages/scripts/components/events/GettingProperties.js
@@ -14,7 +14,7 @@ export default class GettingProperties extends Component {
     content: "Change the zoom level", 
   }
 
-  _handle_zoom_changed () {
+  handleZoomChanged () {
     const zoomLevel = this.refs.map.getZoom();
     if (zoomLevel !== this.state.zoomLevel) {
       // Notice: Check zoomLevel equality here,
@@ -40,7 +40,7 @@ export default class GettingProperties extends Component {
         ref="map"
         defaultCenter={myLatLng}
         zoom={zoomLevel}
-        onZoomChanged={::this._handle_zoom_changed}>
+        onZoomChanged={::this.handleZoomChanged}>
         <InfoWindow
           defaultPosition={myLatLng}
           content={content}

--- a/examples/gh-pages/scripts/components/events/SimpleClickEvent.js
+++ b/examples/gh-pages/scripts/components/events/SimpleClickEvent.js
@@ -1,7 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as Marker} from "../../../../../src/Marker";
+import {GoogleMap, Marker} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/event-simple

--- a/examples/gh-pages/scripts/components/events/SimpleClickEvent.js
+++ b/examples/gh-pages/scripts/components/events/SimpleClickEvent.js
@@ -18,13 +18,13 @@ export default class SimpleClickEvent extends Component {
     center: this.props.initialCenter,
   }
 
-  _handle_marker_click () {
+  handleMarkerClick () {
     this.setState({
       zoom: 8,
     });
   }
 
-  _handle_map_center_changed () {
+  handleMapCenterChanged () {
     const newPos = this.refs.map.getCenter();
     if (newPos.equals(new google.maps.LatLng(this.props.initialCenter))) {
       // Notice: Check newPos equality here,
@@ -61,11 +61,11 @@ export default class SimpleClickEvent extends Component {
         ref="map"
         zoom={zoom}
         center={center}
-        onCenterChanged={::this._handle_map_center_changed}>
+        onCenterChanged={::this.handleMapCenterChanged}>
         <Marker
           defaultPosition={center}
           title="Click to zoom"
-          onClick={::this._handle_marker_click} />
+          onClick={::this.handleMarkerClick} />
       </GoogleMap>
     );
   }

--- a/examples/gh-pages/scripts/components/places/SearchBox.js
+++ b/examples/gh-pages/scripts/components/places/SearchBox.js
@@ -35,14 +35,14 @@ export default class SearchBoxExample extends Component {
     markers: []
   }
 
-  _handle_bounds_changed () {
+  handleBoundsChanged () {
     this.setState({
       bounds: this.refs.map.getBounds(),
       center: this.refs.map.getCenter()
     });
   }
 
-  _handle_places_changed () {
+  handlePlacesChanged () {
     const places = this.refs.searchBox.getPlaces();
     const markers = [];
 
@@ -76,13 +76,13 @@ export default class SearchBoxExample extends Component {
           }
         }}
         defaultZoom={15}
-        onBoundsChanged={::this._handle_bounds_changed}
+        onBoundsChanged={::this.handleBoundsChanged}
         ref="map">
 
         <SearchBox
           bounds={this.state.bounds}
           controlPosition={google.maps.ControlPosition.TOP_LEFT}
-          onPlacesChanged={::this._handle_places_changed}
+          onPlacesChanged={::this.handlePlacesChanged}
           ref="searchBox"
           style={SearchBoxExample.inputStyle} />
 

--- a/examples/gh-pages/scripts/components/places/SearchBox.js
+++ b/examples/gh-pages/scripts/components/places/SearchBox.js
@@ -1,8 +1,6 @@
 import {default as React, Component} from "react";
 
-import {default as GoogleMap} from "../../../../../src/GoogleMap";
-import {default as Marker} from "../../../../../src/Marker";
-import {default as SearchBox} from "../../../../../src/SearchBox";
+import {GoogleMap, Marker, SearchBox} from "react-google-maps";
 
 /*
  * https://developers.google.com/maps/documentation/javascript/examples/places-searchbox


### PR DESCRIPTION
Hi

I made some changes to gh-examples. 

Examples should show how the user will actually use the library. Relative imports of internal modules were not very helpful.

Also in JavaScript we don't see snake_case very often :)

Now the examples have nice copy-paste-run property.

