### PR TITLE
refactor(GoogleMapLoader): introduce loader component interface

### DIFF
--- a/examples/gh-pages/scripts/components/AsyncGettingStarted.js
+++ b/examples/gh-pages/scripts/components/AsyncGettingStarted.js
@@ -66,8 +66,7 @@ export default class AsyncGettingStarted extends Component {
     this.setState({ markers });
   }
 
-  render () {
-    // <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places" />
+  renderDeprecatedBehavior () {// Remove when reach 5.0.0
     return (
       <ScriptjsLoader
         hostname={"maps.googleapis.com"}
@@ -123,5 +122,58 @@ export default class AsyncGettingStarted extends Component {
         }
       />
     );
+  }
+
+  renderNewBehavior () {
+    return (
+      <ScriptjsLoader
+        hostname={"maps.googleapis.com"}
+        pathname={"/maps/api/js"}
+        query={{v: `3.${ AsyncGettingStarted.version }`, libraries: "geometry,drawing,places"}}
+        loadingElement={
+          <div {...this.props} style={{ height: "100%" }}>
+            <FaSpinner
+              style={{
+                display: "block",
+                margin: "150px auto",
+                animation: "fa-spin 2s infinite linear"
+              }}
+            />
+          </div>
+        }
+        containerElement={
+          <div {...this.props} style={{ height: "100%" }} />
+        }
+        googleMapElement={
+          <GoogleMap
+            ref={googleMap => {
+              if (!googleMap) {
+                return;
+              }
+              console.log(googleMap)
+              console.log(`Zoom: ${ googleMap.getZoom() }`);
+              console.log(`Center: ${ googleMap.getCenter() }`);
+            }}
+            defaultZoom={3}
+            defaultCenter={{lat: -25.363882, lng: 131.044922}}
+            onClick={::this.handleMapClick}
+          >
+            {this.state.markers.map((marker, index) => {
+              return (
+                <Marker
+                  {...marker}
+                  onRightclick={this.handleMarkerRightclick.bind(this, index)} />
+              );
+            })}
+          </GoogleMap>
+        }
+      />
+    );
+  }
+
+  render () {
+    // <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places" />
+    // return this.renderDeprecatedBehavior(); // Uncomment for legacy support
+    return this.renderNewBehavior();
   }
 }

--- a/examples/gh-pages/scripts/components/GettingStarted.js
+++ b/examples/gh-pages/scripts/components/GettingStarted.js
@@ -1,7 +1,7 @@
 import {default as React, Component} from "react";
 import {default as update} from "react-addons-update";
 
-import {GoogleMap, Marker} from "react-google-maps";
+import {GoogleMapLoader, GoogleMap, Marker} from "react-google-maps";
 
 /*
  * This is the modify version of:
@@ -64,24 +64,31 @@ export default class GettingStarted extends Component {
 
   render () {
     return (
-      <GoogleMap containerProps={{
-          ...this.props,
-          style: {
-            height: "100%",
-          },
-        }}
-        ref="map"
-        defaultZoom={3}
-        defaultCenter={{lat: -25.363882, lng: 131.044922}}
-        onClick={::this.handleMapClick}>
-        {this.state.markers.map((marker, index) => {
-          return (
-            <Marker
-              {...marker}
-              onRightclick={this.handleMarkerRightclick.bind(this, index)} />
-          );
-        })}
-      </GoogleMap>
+      <GoogleMapLoader
+        containerElement={
+          <div
+            {...this.props}
+            style={{
+              height: "100%",
+            }}
+          />
+        }
+        googleMapElement={
+          <GoogleMap
+            ref={(map) => map && console.log(map.getZoom())}
+            defaultZoom={3}
+            defaultCenter={{lat: -25.363882, lng: 131.044922}}
+            onClick={::this.handleMapClick}>
+            {this.state.markers.map((marker, index) => {
+              return (
+                <Marker
+                  {...marker}
+                  onRightclick={this.handleMarkerRightclick.bind(this, index)} />
+              );
+            })}
+          </GoogleMap>
+        }
+      />
     );
   }
 }

--- a/src/GoogleMapLoader.js
+++ b/src/GoogleMapLoader.js
@@ -1,0 +1,69 @@
+import {
+  default as React,
+  PropTypes,
+  Component,
+} from "react";
+
+import {
+  default as propTypesElementOfType,
+} from "react-prop-types-element-of-type";
+
+import {
+  default as GoogleMapHolder,
+} from "./creators/GoogleMapHolder";
+
+const USE_NEW_BEHAVIOR_TAG_NAME = `__new_behavior__`;/* CIRCULAR_DEPENDENCY */
+
+export default class GoogleMapLoader extends Component {
+  static propTypes = {
+    containerElement: PropTypes.node.isRequired,
+    googleMapElement: PropTypes.element.isRequired,/* CIRCULAR_DEPENDENCY. Uncomment when 5.0.0 comes: propTypesElementOfType(GoogleMap).isRequired, */
+  };
+
+  static defaultProps = {
+    containerElement: (<div />),
+  };
+
+  state = {
+    map: null,
+  };
+
+  mountGoogleMap (domEl) {
+    if (this.state.map) {
+      return;
+    }
+    const {children, ...mapProps} = this.props.googleMapElement.props;
+    //
+    // Create google.maps.Map instance so that dom is initialized before
+    // React's children creators.
+    //
+    const map = GoogleMapHolder._createMap(domEl, mapProps);
+    this.setState({ map });
+  }
+
+  renderChild () {
+    if (this.state.map) {
+      // Notice: implementation details
+      //
+      // In this state, the DOM of google.maps.Map is already initialized in
+      // my innerHTML. Adding extra React components will not clean it
+      // in current version*. It will use prepend to add DOM of
+      // GoogleMapHolder and become a sibling of the DOM of google.maps.Map
+      // Not sure this is subject to change
+      //
+      // *current version: 0.13.3, 0.14.2
+      //
+      return React.cloneElement(this.props.googleMapElement, {
+        map: this.state.map,
+        //------------ Deprecated ------------
+        containerTagName: USE_NEW_BEHAVIOR_TAG_NAME,
+      });
+    }
+  }
+
+  render () {
+    return React.cloneElement(this.props.containerElement, {
+      ref: ::this.mountGoogleMap,
+    }, this.renderChild());
+  }
+}

--- a/src/async/ScriptjsLoader.js
+++ b/src/async/ScriptjsLoader.js
@@ -17,6 +17,7 @@ import {
 } from "warning";
 
 import {
+  GoogleMapLoader,
   GoogleMap,
 } from "../index";
 
@@ -31,14 +32,32 @@ export default class ScriptjsLoader extends Component {
     ...urlObjDefinition,
     // PropTypes for ScriptjsLoader
     loadingElement: PropTypes.node,
+    // ...GoogleMapLoader.propTypes,// Uncomment for 5.0.0
     googleMapElement: propTypesElementOfType(GoogleMap).isRequired,
-  }
+  };
+
+  static defaultProps = {
+  };
 
   state = {
     isLoaded: false,
   }
 
+  shouldUseNewBehavior () {
+    const {containerTagName, containerProps} = this.props.googleMapElement.props;
+    return (
+      null != this.props.containerElement &&
+      undefined === containerTagName &&
+      undefined === containerProps
+    );
+  }
+
   componentWillMount () {
+    warning(this.shouldUseNewBehavior(),
+`"async/ScriptjsLoader" is now rendering "GoogleMapLoader". Migrate to use "GoogleMapLoader" instead. 
+The old behavior will be removed in next major release (5.0.0). 
+See https://github.com/tomchentw/react-google-maps/pull/157 for more details.`
+    );
     if (!canUseDOM) {
       return;
     }
@@ -65,7 +84,15 @@ export default class ScriptjsLoader extends Component {
 
   render () {
     if (this.state.isLoaded) {
-      return this.props.googleMapElement;
+      const {protocol, hostname, port, pathname, query, loadingElement, ...restProps} = this.props;
+
+      if (this.shouldUseNewBehavior()) {
+        return (
+          <GoogleMapLoader {...restProps} />
+        );
+      } else {//------------ Deprecated ------------
+        return this.props.googleMapElement;
+      }
     } else {
       return this.props.loadingElement;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-export {default as GoogleMap} from "./GoogleMap";
+export {default as GoogleMapLoader} from "./GoogleMapLoader";
 
+export {default as GoogleMap} from "./GoogleMap";
 export {default as Circle} from "./Circle";
 export {default as DirectionsRenderer} from "./DirectionsRenderer";
 export {default as DrawingManager} from "./DrawingManager";


### PR DESCRIPTION
# Breaking Changes

## GoogleMap with props.containerProps is now deprecated.

Use `GoogleMapLoader` with `props.googleMapElement` instead

We also suggest switching to [callback based ref](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) so that you'll get the component instance when it is mounted.

Before:

```js
<GoogleMap containerProps={{
    ...this.props,
    style: {
      height: "100%",
    },
  }}
  ref="map"
  defaultZoom={3}
  defaultCenter={{lat: -25.363882, lng: 131.044922}}
  onClick={::this.handleMapClick}>
  {this.state.markers.map((marker, index) => {
    return (
      <Marker
        {...marker}
        onRightclick={this.handleMarkerRightclick.bind(this, index)} />
    );
  })}
</GoogleMap>
```

After:

```js
<GoogleMapLoader
  containerElement={
    <div
      {...this.props}
      style={{
        height: "100%",
      }}
    />
  }
  googleMapElement={
    <GoogleMap
      ref={(map) => console.log(map)}
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
      onClick={::this.handleMapClick}>
      {this.state.markers.map((marker, index) => {
        return (
          <Marker
            {...marker}
            onRightclick={this.handleMarkerRightclick.bind(this, index)} />
        );
      })}
    </GoogleMap>
  }
/>
```

## ScriptjsLoader will delegate to GoogleMapLoader when the script is loaded

Before:

```js
<ScriptjsLoader
  hostname={"maps.googleapis.com"}
  pathname={"/maps/api/js"}
  query={{v: `3.${ AsyncGettingStarted.version }`, libraries: "geometry,drawing,places"}}
  loadingElement={
    <div {...this.props} style={{ height: "100%" }}>
      <FaSpinner />
    </div>
  }
  googleMapElement={
    <GoogleMap
      containerProps={{
        ...this.props,
        style: {
          height: "100%",
        },
      }}
      ref={googleMap => {
        // Wait until GoogleMap is fully loaded. Related to #133
        setTimeout(() => {
          googleMap && console.log(`Zoom: ${ googleMap.getZoom() }`);
        }, 50);
      }}
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
      onClick={::this.handleMapClick}
    >
      <Marker
        {...this.state.marker}
        onRightclick={this.handleMarkerRightclick}
      />
    </GoogleMap>
  }
/>
```

After:

```js
<ScriptjsLoader
  hostname={"maps.googleapis.com"}
  pathname={"/maps/api/js"}
  query={{v: `3.${ AsyncGettingStarted.version }`, libraries: "geometry,drawing,places"}}
  loadingElement={
    <div {...this.props} style={{ height: "100%" }}>
      <FaSpinner />
    </div>
  }
  containerElement={
    <div {...this.props} style={{ height: "100%" }} />
  }
  googleMapElement={
    <GoogleMap
      ref={googleMap => {
        googleMap && console.log(`Zoom: ${ googleMap.getZoom() }`);
      }}
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
      onClick={::this.handleMapClick}
    >
      <Marker
        {...this.state.marker}
        onRightclick={this.handleMarkerRightclick}
      />
    </GoogleMap>
  }
/>
```

# Update examples/gh-pages

You could see the real running code for these new behavior in [examples/gh-pages] folder

