### PR TITLE
feat(GoogleMap): add warning for undefined google object

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "rimraf": "^2.4.3",
-    "thenify": "^3.1.1",
     "tomchentw-npm-dev": "^3.1.0"
   },
   "dependencies": {

--- a/src/__tests__/GoogleMap.spec.js
+++ b/src/__tests__/GoogleMap.spec.js
@@ -2,9 +2,6 @@ import {
   default as expect,
 } from "expect";
 
-import {
-  default as thenify,
-} from "thenify";
 
 import {
   default as React,
@@ -15,7 +12,7 @@ import {
 
 import {
   unmountComponentAtNode,
-  render as renderWithCallback,
+  render,
 } from "react-dom";
 
 import * as maps from "../__mocks__/google.maps.mock";
@@ -24,8 +21,6 @@ import {
   default as GoogleMap,
 } from "../GoogleMap";
 
-const render = thenify(renderWithCallback);
-
 describe(`GoogleMap`, () => {
   before(() => {
     global.google = {maps};
@@ -33,6 +28,39 @@ describe(`GoogleMap`, () => {
 
   after(() => {
     delete global.google;
+  });
+
+  describe(`creation`, () => {
+    context(`global.google is undefined`, () => {
+      let prevGoogle;
+
+      before(() => {
+        prevGoogle = global.google;
+        delete global.google;
+      });
+
+      after(() => {
+        global.google = prevGoogle;
+      });
+
+      it(`should warn and throw error`, () => {
+        const warningSpy = expect.spyOn(console, `error`);
+        expect(warningSpy).toNotHaveBeenCalled();
+
+        let error;
+        try {
+          render((
+            <GoogleMap />
+          ), document.createElement(`div`));
+        } catch (__e__) {
+          error = __e__;
+        }
+        expect(error).toExist();
+        expect(warningSpy).toHaveBeenCalled();
+
+        warningSpy.restore();
+      });
+    });
   });
 
   describe(`rendering`, () => {
@@ -47,36 +75,34 @@ describe(`GoogleMap`, () => {
       domEl = null;
     });
 
-    it(`should call constructor during initial render`, async (done) => {
+    it(`should call constructor during initial render`, () => {
       const constructorSpy = expect.spyOn(maps, `Map`);
       expect(constructorSpy).toNotHaveBeenCalled();
 
-      await render((
+      render((
         <GoogleMap />
       ), domEl);
 
       expect(constructorSpy).toHaveBeenCalled();
 
       constructorSpy.restore();
-      done();
     });
 
-    it(`should call setZoom when props.zoom changes`, async (done) => {
+    it(`should call setZoom when props.zoom changes`, () => {
       const setZoomSpy = expect.spyOn(maps.Map.prototype, `setZoom`);
       expect(setZoomSpy).toNotHaveBeenCalled();
 
-      await render((
+      render((
         <GoogleMap />
       ), domEl);
       expect(setZoomSpy).toNotHaveBeenCalled();
 
-      await render((
+      render((
         <GoogleMap zoom={10} />
       ), domEl);
       expect(setZoomSpy).toHaveBeenCalled();
 
       setZoomSpy.restore();
-      done();
     });
   });
 });

--- a/src/creators/GoogleMapHolder.js
+++ b/src/creators/GoogleMapHolder.js
@@ -5,6 +5,10 @@ import {
   Children,
 } from "react";
 
+import {
+  default as warning,
+} from "warning";
+
 import {default as GoogleMapEventList} from "../eventLists/GoogleMapEventList";
 import {default as eventHandlerCreator} from "../utils/eventHandlerCreator";
 import {default as defaultPropsCreator} from "../utils/defaultPropsCreator";
@@ -56,6 +60,11 @@ export default class GoogleMapHolder extends Component {
   }
 
   static _createMap (domEl, mapProps) {
+    warning(`undefined` !== typeof google,
+`Make sure you've put a <script> tag in your <head> element to load Google Maps JavaScript API v3.
+ If you're looking for built-in support to load it for you, use the "async/ScriptjsLoader" instead.
+ See https://github.com/tomchentw/react-google-maps/pull/168`
+    );
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
     return new google.maps.Map(domEl, composeOptions(mapProps, mapControlledPropTypes));
   }


### PR DESCRIPTION
### Using Loader API

To start rendering `<GoogleMap>`, put it in the props of the `<GoogleMapLoader>` element. Make sure to add <script src="https://maps.googleapis.com/maps/api/js"></script> to your <head> tag to provide google.maps reference

```js
import { GoogleMapLoader } from "react-google-maps";

<GoogleMapLoader
  containerElement={<div/>}
  googleMapElement={
    <GoogleMap
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
    >
      <Marker {...this.props.markerProps} />
    </GoogleMap>
  }
/>
```

### Using Async Loader API

You can also use `<ScriptjsLoader>` introduced in [v4.6.0](https://github.com/tomchentw/react-google-maps/releases/tag/v4.6.0) to load the Google Maps JavaScript API v3 for you.

```js
import {default as FaSpinner} from "react-icons/lib/fa/spinner";
import {default as ScriptjsLoader} from "react-google-maps/lib/async/ScriptjsLoader";

<ScriptjsLoader
  hostname={"maps.googleapis.com"}
  pathname={"/maps/api/js"}
  query={{v: `3.${ AsyncGettingStarted.version }`, libraries: "geometry,drawing,places"}}
  loadingElement={
    <div>
      <FaSpinner />
    </div>
  }
  containerElement={
    <div />
  }
  googleMapElement={
    <GoogleMap
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
    >
      <Marker {...this.props.markerProps} />
    </GoogleMap>
  }
/>
```