### PR TITLE
fix(OverlayViewCreator): position container after render

### DIFF
--- a/lib/creators/OverlayViewCreator.js
+++ b/lib/creators/OverlayViewCreator.js
@@ -104,9 +104,8 @@ var OverlayViewCreator = (function (_Component) {
       };
 
       overlayView.draw = function draw() {
-        this._renderContent();
         this._mountContainerToPane();
-        this._positionContainerElement();
+        this._renderContent();
       };
 
       overlayView.onRemove = function onRemove() {
@@ -116,16 +115,17 @@ var OverlayViewCreator = (function (_Component) {
       };
 
       overlayView._redraw = function _redraw(mapPaneNameChanged) {
-        this._renderContent();
         if (mapPaneNameChanged) {
           this._unmountContainerFromPane();
           this._mountContainerToPane();
         }
-        this._positionContainerElement();
+        this._renderContent();
       };
 
       overlayView._renderContent = function _renderContent() {
-        (0, _reactDom.render)(_react.Children.only(this.get("children")), this._containerElement);
+        if (this._containerElement) {
+          (0, _reactDom.render)(_react.Children.only(this.get("children")), this._containerElement, this._positionContainerElement.bind(this));
+        }
       };
 
       overlayView._mountContainerToPane = function _mountContainerToPane() {

--- a/src/creators/OverlayViewCreator.js
+++ b/src/creators/OverlayViewCreator.js
@@ -53,9 +53,8 @@ export default class OverlayViewCreator extends Component {
     };
 
     overlayView.draw = function draw() {
-      this._renderContent();
       this._mountContainerToPane();
-      this._positionContainerElement();
+      this._renderContent();
     };
 
     overlayView.onRemove = function onRemove() {
@@ -65,19 +64,21 @@ export default class OverlayViewCreator extends Component {
     };
 
     overlayView._redraw = function _redraw(mapPaneNameChanged) {
-      this._renderContent();
       if (mapPaneNameChanged) {
         this._unmountContainerFromPane();
         this._mountContainerToPane();
       }
-      this._positionContainerElement();
+      this._renderContent();
     };
 
     overlayView._renderContent = function _renderContent() {
-      render(
-        Children.only(this.get(`children`)),
-        this._containerElement
-      );
+      if (this._containerElement) {
+        render(
+          Children.only(this.get(`children`)),
+          this._containerElement,
+          this._positionContainerElement.bind(this)
+        );
+      }
     };
 
     overlayView._mountContainerToPane = function _mountContainerToPane() {


### PR DESCRIPTION
Sometimes, the width & height reported to the `getPixelPositionOffset` function are stale (from a previous render). This moves the `_positionContainerElement` method to the callback of the `ReactDOM.render` method to ensure React is done rendering before positioning the container.