### PR TITLE
KmlLayer support

### DIFF
--- a/examples/gh-pages/scripts/components/basics/KmlLayer.js
+++ b/examples/gh-pages/scripts/components/basics/KmlLayer.js
@@ -1,0 +1,45 @@
+import {default as React, Component} from "react";
+
+import {GoogleMap, KmlLayer} from "react-google-maps";
+
+const STYLES = {
+  mapContainer: {
+    height: "100%"
+  }
+};
+
+/*
+ * Add <script src="https://maps.googleapis.com/maps/api/js"></script> to your HTML to provide google.maps reference
+ */
+export default class KmlLayerExample extends Component {
+  state = {
+    count: 0,
+  }
+
+  render () {
+    const {count} = this.state;
+
+    return (
+      <GoogleMap containerProps={{
+          ...this.props,
+          style: {
+            height: "100%",
+          },
+        }}
+        /*
+         * 3. config <GoogleMap> instance by properties
+         */
+        defaultZoom={8}
+        defaultCenter={{lat: 41.876, lng: -87.624}}>
+
+        <KmlLayer
+          url="http://googlemaps.github.io/js-v2-samples/ggeoxml/cta.kml"/>
+
+      </GoogleMap>
+    );
+  }
+
+  onClick () {
+    this.setState({count: this.state.count + 1});
+  }
+}

--- a/examples/gh-pages/scripts/constants/Actions.js
+++ b/examples/gh-pages/scripts/constants/Actions.js
@@ -81,6 +81,17 @@ export const DROPDOWN_ACTIONS = [
       },
     },
   },
+  {
+    key: "basics__kml-layer",
+    displayName: 'KmlLayer',
+    path: '#basics/kml-layer',
+    component: {
+      componentClass: require("../components/basics/KmlLayer"),
+      componentRaw: {
+        __raw: require("!raw-loader!../components/basics/KmlLayer"),
+      },
+    },
+  },
   false,
   {
     key: "events__simple-click-event",

--- a/lib/KmlLayer.js
+++ b/lib/KmlLayer.js
@@ -1,0 +1,117 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _canUseDom = require("can-use-dom");
+
+var _canUseDom2 = _interopRequireDefault(_canUseDom);
+
+var _creatorsKmlLayerCreator = require("./creators/KmlLayerCreator");
+
+var _creatorsKmlLayerCreator2 = _interopRequireDefault(_creatorsKmlLayerCreator);
+
+var KmlLayer = (function (_Component) {
+  _inherits(KmlLayer, _Component);
+
+  function KmlLayer() {
+    _classCallCheck(this, KmlLayer);
+
+    _get(Object.getPrototypeOf(KmlLayer.prototype), "constructor", this).apply(this, arguments);
+
+    this.state = {};
+  }
+
+  _createClass(KmlLayer, [{
+    key: "getDefaultViewport",
+
+    // Public APIs
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+    //
+    // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return it.match(/^get/) && !it.match(/Map$/); })
+    value: function getDefaultViewport() {
+      return this.state.kmlLayer.getDefaultViewport();
+    }
+  }, {
+    key: "getMetadata",
+    value: function getMetadata() {
+      return this.state.kmlLayer.getMetadata();
+    }
+  }, {
+    key: "getStatus",
+    value: function getStatus() {
+      return this.state.kmlLayer.getStatus();
+    }
+  }, {
+    key: "getUrl",
+    value: function getUrl() {
+      return this.state.kmlLayer.getUrl();
+    }
+  }, {
+    key: "getZIndex",
+    value: function getZIndex() {
+      return this.state.marker.getZIndex();
+    }
+
+    // END - Public APIs
+    //
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+
+  }, {
+    key: "componentWillMount",
+    value: function componentWillMount() {
+      if (!_canUseDom2["default"]) {
+        return;
+      }
+      var kmlLayer = _creatorsKmlLayerCreator2["default"]._createKmlLayer(this.props);
+
+      this.setState({ kmlLayer: kmlLayer });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      if (this.state.kmlLayer) {
+        return _react2["default"].createElement(
+          _creatorsKmlLayerCreator2["default"],
+          _extends({ kmlLayer: this.state.kmlLayer }, this.props),
+          this.props.children
+        );
+      } else {
+        return _react2["default"].createElement("noscript", null);
+      }
+    }
+  }], [{
+    key: "propTypes",
+    value: _extends({}, _creatorsKmlLayerCreator.kmlLayerDefaultPropTypes, _creatorsKmlLayerCreator.kmlLayerControlledPropTypes, _creatorsKmlLayerCreator.kmlLayerEventPropTypes),
+    enumerable: true
+  }]);
+
+  return KmlLayer;
+})(_react.Component);
+
+exports["default"] = KmlLayer;
+module.exports = exports["default"];
+
+// Uncontrolled default[props] - used only in componentDidMount
+
+// Controlled [props] - used in componentDidMount/componentDidUpdate
+
+// Event [onEventName]

--- a/lib/creators/KmlLayerCreator.js
+++ b/lib/creators/KmlLayerCreator.js
@@ -1,0 +1,155 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _eventListsKmlLayerEventList = require("../eventLists/KmlLayerEventList");
+
+var _eventListsKmlLayerEventList2 = _interopRequireDefault(_eventListsKmlLayerEventList);
+
+var _utilsEventHandlerCreator = require("../utils/eventHandlerCreator");
+
+var _utilsEventHandlerCreator2 = _interopRequireDefault(_utilsEventHandlerCreator);
+
+var _utilsDefaultPropsCreator = require("../utils/defaultPropsCreator");
+
+var _utilsDefaultPropsCreator2 = _interopRequireDefault(_utilsDefaultPropsCreator);
+
+var _utilsComposeOptions = require("../utils/composeOptions");
+
+var _utilsComposeOptions2 = _interopRequireDefault(_utilsComposeOptions);
+
+var _utilsComponentLifecycleDecorator = require("../utils/componentLifecycleDecorator");
+
+var _utilsComponentLifecycleDecorator2 = _interopRequireDefault(_utilsComponentLifecycleDecorator);
+
+var _GoogleMapHolder = require("./GoogleMapHolder");
+
+var _GoogleMapHolder2 = _interopRequireDefault(_GoogleMapHolder);
+
+var kmlLayerControlledPropTypes = {
+  // NOTICE!!!!!!
+  //
+  // Only expose those with getters & setters in the table as controlled props.
+  //
+  // [].map.call($0.querySelectorAll("tr>td>code", function(it){ return it.textContent; }).filter(function(it){ return it.match(/^set/) && !it.match(/^setMap/); })
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+  defaultViewport: _react.PropTypes.any,
+  metadata: _react.PropTypes.any,
+  status: _react.PropTypes.any,
+  url: _react.PropTypes.string,
+  zIndex: _react.PropTypes.number
+};
+
+exports.kmlLayerControlledPropTypes = kmlLayerControlledPropTypes;
+var kmlLayerDefaultPropTypes = (0, _utilsDefaultPropsCreator2["default"])(kmlLayerControlledPropTypes);
+
+exports.kmlLayerDefaultPropTypes = kmlLayerDefaultPropTypes;
+var kmlLayerUpdaters = {
+  defaultViewport: function defaultViewport(_defaultViewport, component) {
+    component.getKmlLayer().setDefaultViewport(_defaultViewport);
+  },
+  metadata: function metadata(_metadata, component) {
+    component.getKmlLayer().setMetadata(_metadata);
+  },
+  status: function status(_status, component) {
+    component.getKmlLayer().setStatus(_status);
+  },
+  url: function url(_url, component) {
+    component.getKmlLayer().setUrl(_url);
+  },
+  zIndex: function zIndex(_zIndex, component) {
+    component.getKmlLayer().setZIndex(_zIndex);
+  }
+};
+
+var _eventHandlerCreator = (0, _utilsEventHandlerCreator2["default"])(_eventListsKmlLayerEventList2["default"]);
+
+var eventPropTypes = _eventHandlerCreator.eventPropTypes;
+var registerEvents = _eventHandlerCreator.registerEvents;
+var kmlLayerEventPropTypes = eventPropTypes;
+
+exports.kmlLayerEventPropTypes = kmlLayerEventPropTypes;
+
+var KmlLayerCreator = (function (_Component) {
+  _inherits(KmlLayerCreator, _Component);
+
+  function KmlLayerCreator() {
+    _classCallCheck(this, _KmlLayerCreator);
+
+    _get(Object.getPrototypeOf(_KmlLayerCreator.prototype), "constructor", this).apply(this, arguments);
+  }
+
+  _createClass(KmlLayerCreator, [{
+    key: "getKmlLayer",
+    value: function getKmlLayer() {
+      return this.props.kmlLayer;
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _props = this.props;
+      var mapHolderRef = _props.mapHolderRef;
+      var children = _props.children;
+
+      if (_react.Children.count(children) > 0) {
+        return _react2["default"].createElement(
+          "div",
+          null,
+          _react.Children.map(children, function (childElement) {
+            return childElement && _react2["default"].cloneElement(childElement, {
+              mapHolderRef: mapHolderRef
+            });
+          })
+        );
+      } else {
+        return _react2["default"].createElement("noscript", null);
+      }
+    }
+  }], [{
+    key: "_createKmlLayer",
+    value: function _createKmlLayer(kmlLayerProps) {
+      var mapHolderRef = kmlLayerProps.mapHolderRef;
+
+      // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+      var kmlLayer = new google.maps.KmlLayer((0, _utilsComposeOptions2["default"])(kmlLayerProps, kmlLayerControlledPropTypes));
+
+      kmlLayer.setMap(mapHolderRef.getMap());
+
+      return kmlLayer;
+    }
+  }, {
+    key: "propTypes",
+    value: {
+      mapHolderRef: _react.PropTypes.instanceOf(_GoogleMapHolder2["default"]).isRequired,
+      kmlLayer: _react.PropTypes.object.isRequired
+    },
+    enumerable: true
+  }]);
+
+  var _KmlLayerCreator = KmlLayerCreator;
+  KmlLayerCreator = (0, _utilsComponentLifecycleDecorator2["default"])({
+    registerEvents: registerEvents,
+    instanceMethodName: "getKmlLayer",
+    updaters: kmlLayerUpdaters
+  })(KmlLayerCreator) || KmlLayerCreator;
+  return KmlLayerCreator;
+})(_react.Component);
+
+exports["default"] = KmlLayerCreator;

--- a/lib/eventLists/KmlLayerEventList.js
+++ b/lib/eventLists/KmlLayerEventList.js
@@ -1,0 +1,9 @@
+// https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+// [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; })
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = ["click", "defaultviewport_changed", "status_changed"];
+module.exports = exports["default"];

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,10 @@ var _InfoWindow = require("./InfoWindow");
 
 exports.InfoWindow = _interopRequire(_InfoWindow);
 
+var _KmlLayer = require("./KmlLayer");
+
+exports.KmlLayer = _interopRequire(_KmlLayer);
+
 var _Marker = require("./Marker");
 
 exports.Marker = _interopRequire(_Marker);

--- a/src/KmlLayer.js
+++ b/src/KmlLayer.js
@@ -1,0 +1,68 @@
+import {
+  default as React,
+  Component,
+} from "react";
+
+import {
+  default as canUseDOM,
+} from "can-use-dom";
+
+import {
+  default as KmlLayerCreator,
+  kmlLayerDefaultPropTypes,
+  kmlLayerControlledPropTypes,
+  kmlLayerEventPropTypes,
+} from "./creators/KmlLayerCreator";
+
+export default class KmlLayer extends Component {
+  static propTypes = {
+    // Uncontrolled default[props] - used only in componentDidMount
+    ...kmlLayerDefaultPropTypes,
+    // Controlled [props] - used in componentDidMount/componentDidUpdate
+    ...kmlLayerControlledPropTypes,
+    // Event [onEventName]
+    ...kmlLayerEventPropTypes,
+  }
+
+  // Public APIs
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+  //
+  // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; }).filter(function(it){ return it.match(/^get/) && !it.match(/Map$/); })
+  getDefaultViewport() { return this.state.kmlLayer.getDefaultViewport(); }
+
+  getMetadata() { return this.state.kmlLayer.getMetadata(); }
+
+  getStatus() { return this.state.kmlLayer.getStatus(); }
+
+  getUrl() { return this.state.kmlLayer.getUrl(); }
+
+  getZIndex() { return this.state.marker.getZIndex(); }
+  // END - Public APIs
+  //
+  // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+
+  state = {
+  }
+
+  componentWillMount() {
+    if (!canUseDOM) {
+      return;
+    }
+    const kmlLayer = KmlLayerCreator._createKmlLayer(this.props);
+
+    this.setState({ kmlLayer });
+  }
+
+  render() {
+    if (this.state.kmlLayer) {
+      return (
+        <KmlLayerCreator kmlLayer={this.state.kmlLayer} {...this.props}>
+          {this.props.children}
+        </KmlLayerCreator>
+      );
+    } else {
+      return (<noscript />);
+    }
+  }
+}

--- a/src/creators/KmlLayerCreator.js
+++ b/src/creators/KmlLayerCreator.js
@@ -1,0 +1,86 @@
+import {
+  default as React,
+  PropTypes,
+  Component,
+  Children,
+} from "react";
+
+import { default as KmlLayerEventList } from "../eventLists/KmlLayerEventList";
+import { default as eventHandlerCreator } from "../utils/eventHandlerCreator";
+import { default as defaultPropsCreator } from "../utils/defaultPropsCreator";
+import { default as composeOptions } from "../utils/composeOptions";
+import { default as componentLifecycleDecorator } from "../utils/componentLifecycleDecorator";
+
+import { default as GoogleMapHolder } from "./GoogleMapHolder";
+
+export const kmlLayerControlledPropTypes = {
+// NOTICE!!!!!!
+//
+// Only expose those with getters & setters in the table as controlled props.
+//
+// [].map.call($0.querySelectorAll("tr>td>code", function(it){ return it.textContent; }).filter(function(it){ return it.match(/^set/) && !it.match(/^setMap/); })
+//
+// https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+  defaultViewport: PropTypes.any,
+  metadata: PropTypes.any,
+  status: PropTypes.any,
+  url: PropTypes.string,
+  zIndex: PropTypes.number,
+};
+
+export const kmlLayerDefaultPropTypes = defaultPropsCreator(kmlLayerControlledPropTypes);
+
+const kmlLayerUpdaters = {
+  defaultViewport(defaultViewport, component) { component.getKmlLayer().setDefaultViewport(defaultViewport); },
+  metadata(metadata, component) { component.getKmlLayer().setMetadata(metadata); },
+  status(status, component) { component.getKmlLayer().setStatus(status); },
+  url(url, component) { component.getKmlLayer().setUrl(url); },
+  zIndex(zIndex, component) { component.getKmlLayer().setZIndex(zIndex); },
+};
+
+const { eventPropTypes, registerEvents } = eventHandlerCreator(KmlLayerEventList);
+
+export const kmlLayerEventPropTypes = eventPropTypes;
+
+@componentLifecycleDecorator({
+  registerEvents,
+  instanceMethodName: `getKmlLayer`,
+  updaters: kmlLayerUpdaters,
+})
+export default class KmlLayerCreator extends Component {
+
+  static propTypes = {
+    mapHolderRef: PropTypes.instanceOf(GoogleMapHolder).isRequired,
+    kmlLayer: PropTypes.object.isRequired,
+  }
+
+  static _createKmlLayer(kmlLayerProps) {
+    const { mapHolderRef } = kmlLayerProps;
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+    const kmlLayer = new google.maps.KmlLayer(composeOptions(kmlLayerProps, kmlLayerControlledPropTypes));
+
+    kmlLayer.setMap(mapHolderRef.getMap());
+
+    return kmlLayer;
+  }
+
+  getKmlLayer() {
+    return this.props.kmlLayer;
+  }
+
+  render() {
+    const { mapHolderRef, children } = this.props;
+
+    if (Children.count(children) > 0) {
+      return (
+        <div>{Children.map(children, childElement =>
+          childElement && React.cloneElement(childElement, {
+            mapHolderRef,
+          })
+        )}</div>
+      );
+    } else {
+      return (<noscript />);
+    }
+  }
+}

--- a/src/eventLists/KmlLayerEventList.js
+++ b/src/eventLists/KmlLayerEventList.js
@@ -1,0 +1,7 @@
+// https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
+// [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; })
+export default [
+  `click`,
+  `defaultviewport_changed`,
+  `status_changed`,
+];

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { default as Circle } from "./Circle";
 export { default as DirectionsRenderer } from "./DirectionsRenderer";
 export { default as DrawingManager } from "./DrawingManager";
 export { default as InfoWindow } from "./InfoWindow";
+export { default as KmlLayer } from "./KmlLayer";
 export { default as Marker } from "./Marker";
 export { default as OverlayView } from "./OverlayView";
 export { default as Polygon } from "./Polygon";


### PR DESCRIPTION
This change adds support for KmlLayers to react-google-maps. It also adds a KmlLayer example to gh-pages based on Google's own tutorial found here:
https://developers.google.com/maps/documentation/javascript/examples/layer-kml

Please let me know if I've missed anything and I will take care of it ASAP.