### PR TITLE
Let `OverlayView` be clusterd in `MarkerClusterer`

### DIFF
--- a/src/creators/OverlayViewCreator.js
+++ b/src/creators/OverlayViewCreator.js
@@ -137,8 +137,7 @@ export default class OverlayViewCreator extends Component {
 
     // If we're inside a MarkerClusterer, allow ourselves to be clustered
     if (overlayViewProps.anchorHolderRef) {
-      if ('MarkerClusterer' === overlayViewProps.anchorHolderRef.getAnchorType()) {
-
+      if (`MarkerClusterer` === overlayViewProps.anchorHolderRef.getAnchorType()) {
         overlayView.getDraggable = function getDraggable() {
           return !!overlayViewProps.draggable;
         };

--- a/src/creators/OverlayViewCreator.js
+++ b/src/creators/OverlayViewCreator.js
@@ -135,6 +135,22 @@ export default class OverlayViewCreator extends Component {
       }
     };
 
+    // If we're inside a MarkerClusterer, allow ourselves to be clustered
+    if (overlayViewProps.anchorHolderRef) {
+      if ('MarkerClusterer' === overlayViewProps.anchorHolderRef.getAnchorType()) {
+
+        overlayView.getDraggable = function getDraggable() {
+          return !!overlayViewProps.draggable;
+        };
+
+        overlayView.getPosition = function getPosition() {
+          return new google.maps.LatLng(this.position);
+        };
+
+        overlayViewProps.anchorHolderRef.getAnchor().addMarker(overlayView);
+      }
+    }
+
     return overlayView;
   }
 


### PR DESCRIPTION
Since `OverlayView` can represent any kind of overlay, including extremely
custom markers, it makes sense to allow it to be clustered. For this to work,
we only have to implement two functions of the `Marker` class: `getDraggable`
and `getPosition`.

The `MarkerClusterer` will call our `OverlayView`'s `setVisible` method as
needed.