### PR TITLE
docs(gh-pages): add Pop-up InfoWindow nesting example

### DIFF
--- a/examples/gh-pages/src/containers/Application.js
+++ b/examples/gh-pages/src/containers/Application.js
@@ -88,6 +88,7 @@ export default class Application extends Component {
               <MenuItem href="#basics/directions">Directions</MenuItem>
               <MenuItem href="#basics/overlay-view">Overlay view</MenuItem>
               <MenuItem href="#basics/kml-layer">KmlLayer</MenuItem>
+              <MenuItem href="#basics/pop-up-window">Pop-up InfoWindow</MenuItem> 
               <MenuItem divider />
               <MenuItem href="#events/simple-click-event">Simple click event</MenuItem>
               <MenuItem href="#events/closure-listeners">Using closures in event listeners</MenuItem>

--- a/examples/gh-pages/src/pages/basics/PopUpInfoWindow.js
+++ b/examples/gh-pages/src/pages/basics/PopUpInfoWindow.js
@@ -1,0 +1,137 @@
+import { default as React, Component } from "react";
+
+import { GoogleMapLoader, GoogleMap, InfoWindow, Marker } from "react-google-maps";
+
+/*
+ *
+ *  Add <script src="https://maps.googleapis.com/maps/api/js"></script>
+ *  to your HTML to provide google.maps reference
+ * 
+ */
+export default class PopUpInfoWindow extends Component {
+
+  state = {
+    center: {
+      lat: -25.363882,
+      lng: 131.044922,
+    },
+    
+    //array of objects of markers
+    markers: [
+      {
+        position: new google.maps.LatLng(-27.363882, 137.044922),
+        showInfo: false
+      },
+      {
+        position: new google.maps.LatLng(-23.363882, 129.044922),
+        showInfo: false  
+      }
+    ]
+  }
+  
+  //Toggle to 'true' to show InfoWindow and re-renders component
+  handleMarkerClick(marker) {
+    marker.showInfo = true;
+    this.setState(this.state);
+  }
+  
+  handleMarkerClose(marker) {
+    marker.showInfo = false;
+    this.setState(this.state);
+  }
+  
+  renderInfoWindow(ref, marker) {
+    
+    return (
+      
+      //You can nest components inside of InfoWindow!
+      <InfoWindow 
+        key={`${ref}_info_window`}
+        onCloseclick={this.handleMarkerClose.bind(this, marker)} >
+        
+        {ref === 'marker_1' ? 
+        
+        <div>
+          <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" 
+            width="16" height="16" viewBox="0 0 16 16">
+            <path d="M6 14.5c0 .828-.672 1.5-1.5 1.5S3 15.328 3 14.5 3.672
+              13 4.5 13s1.5.672 1.5 1.5zM16 14.5c0 .828-.672 1.5-1.5 
+              1.5s-1.5-.672-1.5-1.5.672-1.5 1.5-1.5 1.5.672 1.5 1.5zM16 
+              8V2H4c0-.552-.448-1-1-1H0v1h2l.75 6.438C2.294 8.805 2 9.368
+              2 10c0 1.105.895 2 2 2h12v-1H4c-.552 0-1-.448-1-1v-.01L16 8z"/>
+          </svg>
+        </div>  
+        
+        :
+        
+        <div>
+          <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" 
+            width="16" height="16" viewBox="0 0 16 16">
+            <path d="M3.5 0c-1.7 0-3 1.6-3 3.5 0 1.7 1 3 2.3 3.4l-.5 8c0 
+              .6.4 1 1 1h.5c.5 0 1-.4 1-1L4 7C5.5 6.4 6.5 5 6.5 
+              3.4c0-2-1.3-3.5-3-3.5zm10 0l-.8 5h-.6l-.3-5h-.4L11 
+              5H10l-.8-5H9v6.5c0 .3.2.5.5.5h1.3l-.5 8c0 .6.4 1 1 1h.4c.6 0 
+              1-.4 1-1l-.5-8h1.3c.3 0 .5-.2.5-.5V0h-.4z"/>
+          </svg>
+        </div>
+        
+        }
+      
+      </InfoWindow>
+      
+    );
+    
+  }
+
+  render() {
+
+    return (
+      
+      <GoogleMapLoader
+        containerElement={
+          <div
+            {...this.props}
+            style={{
+              height: '100%'
+            }} >
+          </div>
+        }
+        googleMapElement={
+          <GoogleMap 
+            center={this.state.center}
+            defaultZoom={4}
+            ref='map'>
+            
+            {this.state.markers.map((marker, index) => 
+              
+              {
+              
+              const ref = `marker_${index}`;
+              
+              return ( <Marker 
+                key={index}
+                ref={ref}
+                position={marker.position}
+                onClick={this.handleMarkerClick.bind(this, marker)} >
+                
+                {/* 
+                  Show info window only if the 'showInfo' key of the marker is true. 
+                  That is, when the Marker pin has been clicked and 'handleMarkerClick' has been
+                  Successfully fired.
+                */}
+                {marker.showInfo ? this.renderInfoWindow(ref, marker) : null}
+                
+              </Marker>
+              );
+                
+              }) 
+            } 
+          
+          </GoogleMap>
+        }
+      
+      /> //end of GoogleMapLoader
+        
+    );
+  }
+}

--- a/examples/gh-pages/src/pages/basics/index.js
+++ b/examples/gh-pages/src/pages/basics/index.js
@@ -22,12 +22,17 @@ import {
   default as KmlLayerExample,
 } from "./KmlLayerExample";
 
+import { 
+  default as PopUpInfoWindow, 
+} from "./PopUpInfoWindow"
+
 SimpleMap.__raw = require(`!raw-loader!./SimpleMap`);
 StyledMap.__raw = require(`!raw-loader!./StyledMap`);
 Geolocation.__raw = require(`!raw-loader!./Geolocation`);
 Directions.__raw = require(`!raw-loader!./Directions`);
 OverlayView.__raw = require(`!raw-loader!./OverlayView`);
 KmlLayerExample.__raw = require(`!raw-loader!./KmlLayerExample`);
+PopUpInfoWindow.__raw = require(`!raw-loader!./PopUpInfoWindow`);
 
 export {
   SimpleMap,
@@ -36,4 +41,5 @@ export {
   Directions,
   OverlayView,
   KmlLayerExample,
+  PopUpInfoWindow
 };

--- a/examples/gh-pages/src/views/routes.js
+++ b/examples/gh-pages/src/views/routes.js
@@ -24,6 +24,7 @@ import {
   Directions,
   OverlayView,
   KmlLayerExample,
+  PopUpInfoWindow
 } from "../pages/basics";
 
 import {
@@ -55,6 +56,7 @@ export default (
       <Route path="directions" component={Directions}/>
       <Route path="overlay-view" component={OverlayView}/>
       <Route path="kml-layer" component={KmlLayerExample}/>
+      <Route path="pop-up-window" component={PopUpInfoWindow} />
     </Route>
     <Route path="events">
       <Route path="simple-click-event" component={SimpleClickEvent}/>


### PR DESCRIPTION
Added an example for nested InfoWindows for gh-pages.

![Menu look](https://cloud.githubusercontent.com/assets/13400593/13209695/decf7d56-d8db-11e5-940c-135b1249cadf.jpg)

![Pop up window](https://cloud.githubusercontent.com/assets/13400593/13209702/f1001008-d8db-11e5-8474-9902eacaa505.jpg)

A separate page apart from 'Using closures in event listeners' example to glean information about InfoWindow being able to nest components would help new users adopt react-google-maps more easily. Further, the InfoWindow is a vital component to react-google-map's usability, and thus should be prominently exemplified. 