### PR TITLE
Update SimpleMap Component Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ export default function SimpleMap (props) {
       <GoogleMapLoader
         containerElement={
           <div
-            {...this.props}
+            {...props.containerElementProps}
             style={{
               height: "100%",
             }}
@@ -27,13 +27,14 @@ export default function SimpleMap (props) {
           <GoogleMap
             ref={(map) => console.log(map)}
             defaultZoom={3}
-            defaultCenter={{lat: -25.363882, lng: 131.044922}}
-            onClick={::this.handleMapClick}>
-            {this.state.markers.map((marker, index) => {
+            defaultCenter={{ lat: -25.363882, lng: 131.044922 }}
+            onClick={props.onMapClick}
+          >
+            {props.markers.map((marker, index) => {
               return (
                 <Marker
                   {...marker}
-                  onRightclick={this.handleMarkerRightclick.bind(this, index)} />
+                  onRightclick={() => props.onMarkerRightclick(index)} />
               );
             })}
           </GoogleMap>


### PR DESCRIPTION
I may be missing something, but from what I could tell, the SimpleMap code example listed in the README file is not actually valid code... I was unable to get it working without bind() errors. It also heavily uses the 'this' keyword and .bind() despite being defined as a pure (stateless) functional component, which is uncommon and a little confusing (especially if someone were to define it using an arrow function without understanding how it differs).

I updated it to be more like the sample SimpleMap linked here: 

https://github.com/tomchentw/react-google-maps_examples_simple-map/blob/493c95b5830a36434d648b9d7f779f231d2c79a5/src/scripts/SimpleMap.js

For now, I replaced the {...props} spread in GoogleMapLoader with {...props.containerElementProps}, as the click handlers are now being passed in as props too. I'm not sure if this is the best approach though...

If you don't like this solution (where everything needed is passed in as a prop), maybe the example should use an ES6 class instead of a pure function?

EDIT: I think I may have overlooked something and that's why I was having issues with the .bind() calls. Sorry for that. However, I do think getting rid of 'this' and 'bind()' would be ideal when using a functional component as an example. Also, we could go one step further and use destructuring assignment in the SimpleMap parameters to get rid of the props references.