### PR TITLE
Update GoogleMapLoader.js

### DIFF
--- a/src/GoogleMapLoader.js
+++ b/src/GoogleMapLoader.js
@@ -25,7 +25,7 @@ export default class GoogleMapLoader extends Component {
   };
 
   mountGoogleMap(domEl) {
-    if (this.state.map) {
+    if (this.state.map || domEl === null) {
       return;
     }
     const { children, ...mapProps } = this.props.googleMapElement.props;


### PR DESCRIPTION
There are some cases when ref callback returns null
it leads to error : "Uncaught TypeError: Cannot read property 'offsetWidth' of null"

quote from react doc:
> Note that when the referenced component is unmounted and whenever the ref changes, the old ref will be called with null as an argument. This prevents memory leaks in the case that the instance is stored, as in the first example. Also note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with null immediately before it's called with the component instance.

https://facebook.github.io/react/docs/more-about-refs.html