### PR TITLE
Fix #255 by bumping marker-clusterer-plus dependency to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "google-maps-infobox": "^1.1.13",
     "invariant": "^2.1.1",
     "lodash.isequal": "^3.0.4",
-    "marker-clusterer-plus": "^2.1.3",
+    "marker-clusterer-plus": "^2.1.4",
     "react-prop-types-element-of-type": "^2.1.0",
     "scriptjs": "^2.5.8",
     "warning": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "google-maps-infobox": "^1.1.13",
     "invariant": "^2.1.1",
     "lodash.isequal": "^3.0.4",
-    "marker-clusterer-plus": "^2.1.2",
+    "marker-clusterer-plus": "^2.1.3",
     "react-prop-types-element-of-type": "^2.1.0",
     "scriptjs": "^2.5.8",
     "warning": "^2.1.0"


### PR DESCRIPTION
Recently fixed the broken image urls in one of the dependencies, this PR just bumps the dep version so it's fixed in react-google-maps.

https://github.com/mikesaidani/marker-clusterer-plus/pull/2

This will fail builds until @mikesaidani merges https://github.com/mikesaidani/marker-clusterer-plus/pull/3 (which bumps the package version on his side so that recent changes can be installed via npm).