### PR TITLE
Feature/switch to standard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "rimraf": "^2.5.2",
+    "standard-version": "^2.2.1",
     "tomchentw-npm-dev": "^3.3.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-dom": "^15.1.0",
     "rimraf": "^2.5.2",
     "standard-version": "^2.2.1",
-    "tomchentw-npm-dev": "^3.3.0"
+    "tomchentw-npm-dev": "^4.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "pretest": "npm run lint",
     "test:cov": "cross-env NODE_ENV=test babel-node ./node_modules/.bin/isparta cover --report lcov _mocha -- $npm_package_config_mocha",
     "test:watch": "npm test -- --watch",
-    "test": "cross-env NODE_ENV=test mocha $npm_package_config_mocha"
+    "test": "cross-env NODE_ENV=test mocha $npm_package_config_mocha",
+    "prerelease": "npm run build && git add -A && git commit -m 'chore(lib): compile from src using babel'",
+    "release": "standard-version"
   },
   "config": {
     "mocha": "--compilers js:babel-register ./src/**/__tests__/*.spec.js --require ./src/__tests__/setup.js"


### PR DESCRIPTION
## Depends on

* #269 

## What `CHANGELOD.md` will look like for 5.0.0

```md
# Change Log

All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

<a name="5.0.0"></a>
# [5.0.0](https://github.com/tomchentw/react-google-maps/compare/v4.11.0...v5.0.0) (2016-05-30)


### Bug Fixes

* **src:** eslint errors ([f2b242a](https://github.com/tomchentw/react-google-maps/commit/f2b242a))


### Features

* **package.json:** upgrade devDependencies ([47a400c](https://github.com/tomchentw/react-google-maps/commit/47a400c))


### Performance Improvements

* **src:** switch mapHolderRef from props to context ([c2d265c](https://github.com/tomchentw/react-google-maps/commit/c2d265c)), closes [#135](https://github.com/tomchentw/react-google-maps/issues/135) [#210](https://github.com/tomchentw/react-google-maps/issues/210) [#216](https://github.com/tomchentw/react-google-maps/issues/216)


### BREAKING CHANGES

* src: If you're just using the library and didn't make custom components before, feel free to ignore this implementation changes.

Now, mapHolderRef for each component are now passed in via context. This doesn't affect all components interface in general. But if you do custom components before and relies on the implementation of react-google-maps, you should be aware of this and make some changes.
```