### PR TITLE
Add another component to load the GMaps JS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,35 @@ All components are available on the top-level export.
 import { GoogleMap, Marker, SearchBox } from "react-google-maps";
 ```
 
+### Loading Libraries
+
+To use this component, you are going to need to load the [Google Maps Javascript API].
+It is optional, but recommended, to specify the libraries you will be using as well as your API key.
+
+You could do it synchronously like so:
+
+```html
+<script type="text/javascript"
+      src="https://maps.googleapis.com/maps/api/js?key=[YOUR_API_KEY]&libraries=geometry,places,visualization">
+</script>
+```
+
+```js
+<GoogleMapLoader
+        query={{ libraries: "geometry,drawing,places,visualization" }}
+  ...
+```
+
+Or asynchronously using the ScriptjsLoader:
+
+```js
+<ScriptjsLoader
+  hostname={"maps.googleapis.com"}
+  pathname={"/maps/api/js"}
+  query={{ key: "[YOUR_API_KEY]", libraries: "geometry,drawing,places" }}
+  ...
+```
+
 ### Trigger events
 
 `triggerEvent(component, ...args)`: One common event trigger is to resize map after the size of the container div change.
@@ -219,3 +248,5 @@ Then open [http://localhost:8080/webpack-dev-server/](http://localhost:8080/webp
 [examples_gh_pages]: https://github.com/tomchentw/react-google-maps/tree/master/examples/gh-pages
 [webpack]: http://webpack.github.io/docs/tutorials/getting-started/
 [conventional-changelog]: https://github.com/ajoslin/conventional-changelog
+
+[Google Maps Javascript API]: https://developers.google.com/maps/documentation/javascript/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ All components are available on the top-level export.
 import { GoogleMap, Marker, SearchBox } from "react-google-maps";
 ```
 
+## Loading Libraries
+
+```html
+<script type="text/javascript"
+      src="https://maps.googleapis.com/maps/api/js?key=<<YOUR_API_HERE>>&libraries=geometry,places,visualization">
+</script>
+```
+
+```js
+<GoogleMapLoader
+        query={{ libraries: `geometry,drawing,places,visualization` }}
+  ...
+```
+
+Or using ScriptjsLoader:
+
+```js
+<ScriptjsLoader
+  hostname={"maps.googleapis.com"}
+  pathname={"/maps/api/js"}
+  query={{ key: 'YOUR_API_KEY', libraries: 'geometry,drawing,places' }}
+  ...
+```
+
 ### Trigger events
 
 `triggerEvent(component, ...args)`: One common event trigger is to resize map after the size of the container div change.

--- a/README.md
+++ b/README.md
@@ -107,30 +107,6 @@ All components are available on the top-level export.
 import { GoogleMap, Marker, SearchBox } from "react-google-maps";
 ```
 
-## Loading Libraries
-
-```html
-<script type="text/javascript"
-      src="https://maps.googleapis.com/maps/api/js?key=<<YOUR_API_HERE>>&libraries=geometry,places,visualization">
-</script>
-```
-
-```js
-<GoogleMapLoader
-        query={{ libraries: `geometry,drawing,places,visualization` }}
-  ...
-```
-
-Or using ScriptjsLoader:
-
-```js
-<ScriptjsLoader
-  hostname={"maps.googleapis.com"}
-  pathname={"/maps/api/js"}
-  query={{ key: 'YOUR_API_KEY', libraries: 'geometry,drawing,places' }}
-  ...
-```
-
 ### Trigger events
 
 `triggerEvent(component, ...args)`: One common event trigger is to resize map after the size of the container div change.

--- a/src/async/LoadGoogleMaps.js
+++ b/src/async/LoadGoogleMaps.js
@@ -1,0 +1,112 @@
+import {
+  default as React,
+  Component,
+  PropTypes,
+} from "react";
+
+import {
+  default as canUseDOM,
+} from "can-use-dom";
+
+import {
+  default as warning,
+} from "warning";
+
+import {
+  default as makeUrl,
+  urlObjDefinition,
+  getUrlObjChangedKeys,
+} from "../utils/makeUrl";
+
+
+/**
+ * Usage:
+ *
+ *     <LoadGoogleMaps query="places" loadingElement={<Spinner />} />
+ *        { () => <GoogleMap {...props}> }
+ *     </LoadGoogleMaps>
+ *
+ * By default, will only render the child once the GMaps JavaScript
+ * has been loaded.
+ *
+ *     <LoadGoogleMaps query="places" passIsLoadingProp={true} />
+ *        { () => <MyGoogleMapWrapper {...props}> }
+ *     </LoadGoogleMaps>
+ *
+ * This will render the children immediately, and pass a isMapsLoaded
+ * property. This allows your child component to decide how it wants
+ * to render a loading indicator.
+ */
+export class LoadGoogleMaps extends Component {
+  static propTypes = {
+    ...urlObjDefinition,
+    children: PropTypes.func.isRequired,
+    loadingElement: PropTypes.node,
+    passIsLoadingProp: PropTypes.bool
+  };
+
+  static defaultProps = {
+    passIsLoadingProp: false
+  };
+
+  state = {
+    isLoaded: false,
+  }
+
+  componentWillMount() {
+    if (!canUseDOM) {
+      return;
+    }
+    /*
+     * External commonjs require dependency -- begin
+     */
+    const scriptjs = require(`scriptjs`); // eslint-disable-line global-require
+    /*
+     * External commonjs require dependency -- end
+     */
+    const { protocol, hostname, port, pathname, query } = this.props;
+    const urlObj = { protocol, hostname, port, pathname, query };
+    const url = makeUrl(urlObj);
+    scriptjs(url, () => this.setState({ isLoaded: true }));
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (`production` !== process.env.NODE_ENV) {
+      const changedKeys = getUrlObjChangedKeys(this.props, nextProps);
+
+      warning(
+        changedKeys.length === 0,
+`LoadGoogleMaps doesn't support mutating url related props after initial render.
+Changed props: %s`,
+`[${changedKeys.join(`, `)}]`
+      );
+    }
+  }
+
+  render() {
+    const funcChild = this.props.children;
+
+    if (this.props.passIsLoadingProp)
+      return funcChild(this.state.isLoaded);
+
+    if (this.state.isLoaded)
+      return funcChild();
+
+    return this.props.loadingElement || null;
+  }
+}
+
+
+export default function loadGoogleMaps(urlOpts) {
+  return function decorator(Component) {
+    return (props) => {
+      return <LoadGoogleMaps {...urlOpts}>
+        {
+          (isLoaded) => {
+            return <Component {...props} isMapsLoaded={isLoaded} />
+          }
+        }
+      </LoadGoogleMaps>
+    }
+  }
+}


### PR DESCRIPTION
This is my approach to solve #281 - letting the library load the Google Maps JavaScript file for me when I need it but still being able to access the ``google`` namespace. This is inspired by how ``react-motion`` uses a single-function child.

It's also nice to use this with the decorator, from my project:

     @loadGoogleMaps({
         hostname: "maps.googleapis.com",
         pathname: "/maps/api/js",
         query: { key: "", libraries: "places" },
         passIsLoadingProp: true
     })
     class PositionSelector extends Component {
     }