### PR TITLE
Feature/remove deprecated use of google maps

### DIFF
--- a/examples/gh-pages/package.json
+++ b/examples/gh-pages/package.json
@@ -34,7 +34,7 @@
     "react-bootstrap": "^0.29.4",
     "react-dom": "^15.1.0",
     "react-github-fork-ribbon": "^0.4.4",
-    "react-google-maps": "^4.11.0",
+    "react-google-maps": "file:../..",
     "react-helmet": "^3.1.0",
     "react-icons": "^2.1.0",
     "react-prism": "^3.2.0",

--- a/examples/gh-pages/src/pages/GettingStarted.js
+++ b/examples/gh-pages/src/pages/GettingStarted.js
@@ -92,7 +92,9 @@ export default class GettingStarted extends Component {
 
   handleGoogleMapLoad(googleMap) {
     this._googleMapComponent = googleMap;
-    console.log(googleMap.getZoom());
+    if (googleMap) {
+      console.log(googleMap.getZoom());
+    }
   }
 
   render() {
@@ -114,7 +116,7 @@ export default class GettingStarted extends Component {
             onClick={::this.handleMapClick}
           >
             {this.state.markers.map((marker, index) => {
-              const onRightclick = this.handleMarkerRightclick.bind(this, index);
+              const onRightclick = () => this.handleMarkerRightclick(index);
               return (
                 <Marker
                   {...marker}

--- a/examples/gh-pages/src/pages/basics/PopUpInfoWindow.js
+++ b/examples/gh-pages/src/pages/basics/PopUpInfoWindow.js
@@ -129,7 +129,7 @@ export default class PopUpInfoWindow extends Component {
           >
             {this.state.markers.map((marker, index) => {
               const ref = `marker_${index}`;
-              const onClick = this.handleMarkerClick.bind(this, marker);
+              const onClick = () => this.handleMarkerClick(marker);
 
               return (
                 <Marker

--- a/examples/gh-pages/src/pages/events/ClosureListeners.js
+++ b/examples/gh-pages/src/pages/events/ClosureListeners.js
@@ -111,7 +111,7 @@ export default class ClosureListeners extends Component {
       >
         {markers.map((marker, index) => {
           const ref = `marker_${index}`;
-          const onClick = this.handleMarkerClick.bind(this, marker);
+          const onClick = () => this.handleMarkerClick(marker);
 
           return (
             <Marker

--- a/src/GoogleMap.js
+++ b/src/GoogleMap.js
@@ -1,12 +1,12 @@
 import {
+  default as invariant,
+} from "invariant";
+
+import {
   default as React,
   PropTypes,
   Component,
 } from "react";
-
-import {
-  default as warning,
-} from "warning";
 
 import {
   default as GoogleMapHolder,
@@ -15,16 +15,8 @@ import {
   mapEventPropTypes,
 } from "./creators/GoogleMapHolder";
 
-import {
-  default as GoogleMapLoader,
-} from "./GoogleMapLoader";
-
-const USE_NEW_BEHAVIOR_TAG_NAME = `__new_behavior__`;
-
 export default class GoogleMap extends Component {
   static propTypes = {
-    containerTagName: PropTypes.string,
-    containerProps: PropTypes.object,
     map: PropTypes.object,
     // Uncontrolled default[props] - used only in componentDidMount
     ...mapDefaultPropTypes,
@@ -40,23 +32,23 @@ export default class GoogleMap extends Component {
   //
   // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; })
   //    .filter(function(it){ return it.match(/^get/) && !it.match(/Map$/); })
-  getBounds() { return (this.props.map || this.refs.delegate).getBounds(); }
+  getBounds() { return this.props.map.getBounds(); }
 
-  getCenter() { return (this.props.map || this.refs.delegate).getCenter(); }
+  getCenter() { return this.props.map.getCenter(); }
 
-  getDiv() { return (this.props.map || this.refs.delegate).getDiv(); }
+  getDiv() { return this.props.map.getDiv(); }
 
-  getHeading() { return (this.props.map || this.refs.delegate).getHeading(); }
+  getHeading() { return this.props.map.getHeading(); }
 
-  getMapTypeId() { return (this.props.map || this.refs.delegate).getMapTypeId(); }
+  getMapTypeId() { return this.props.map.getMapTypeId(); }
 
-  getProjection() { return (this.props.map || this.refs.delegate).getProjection(); }
+  getProjection() { return this.props.map.getProjection(); }
 
-  getStreetView() { return (this.props.map || this.refs.delegate).getStreetView(); }
+  getStreetView() { return this.props.map.getStreetView(); }
 
-  getTilt() { return (this.props.map || this.refs.delegate).getTilt(); }
+  getTilt() { return this.props.map.getTilt(); }
 
-  getZoom() { return (this.props.map || this.refs.delegate).getZoom(); }
+  getZoom() { return this.props.map.getZoom(); }
   // END - Public APIs
   //
   // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
@@ -68,58 +60,32 @@ export default class GoogleMap extends Component {
   //
   // [].map.call($0.querySelectorAll("tr>td>code"), function(it){ return it.textContent; })
   //    .filter(function(it){ return !it.match(/^get/) && !it.match(/^set/) && !it.match(/Map$/); })
-  fitBounds(bounds) { return (this.props.map || this.refs.delegate).fitBounds(bounds); }
+  fitBounds(bounds) { return this.props.map.fitBounds(bounds); }
 
-  panBy(x, y) { return (this.props.map || this.refs.delegate).panBy(x, y); }
+  panBy(x, y) { return this.props.map.panBy(x, y); }
 
-  panTo(latLng) { return (this.props.map || this.refs.delegate).panTo(latLng); }
+  panTo(latLng) { return this.props.map.panTo(latLng); }
 
   panToBounds(latLngBounds) {
-    return (this.props.map || this.refs.delegate).panToBounds(latLngBounds);
+    return this.props.map.panToBounds(latLngBounds);
   }
   // END - Public APIs - Use this carefully
   //
   // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
 
   componentWillMount() {
-    const { containerTagName } = this.props;
-    const isUsingNewBehavior = USE_NEW_BEHAVIOR_TAG_NAME === containerTagName;
-
-    warning(isUsingNewBehavior,
-`"GoogleMap" with containerTagName is deprecated now and will be removed in
- next major release (5.0.0). Use "GoogleMapLoader" instead.
-See https://github.com/tomchentw/react-google-maps/pull/157 for more details.`
-    );
+    const { containerTagName, containerProps } = this.props;
+    invariant(!containerTagName && !containerProps,
+`"GoogleMap" with containerTagName or containerProps is removed in release (5.0.0).
+Use "GoogleMapLoader" instead.
+See https://github.com/tomchentw/react-google-maps/pull/317 for more details.`);
   }
 
   render() {
-    const { containerTagName, containerProps = {}, children, ...mapProps } = this.props;
-    const isUsingNewBehavior = USE_NEW_BEHAVIOR_TAG_NAME === containerTagName;
-
-    if (isUsingNewBehavior) {
-      return (
-        <GoogleMapHolder {...mapProps}>
-          {children}
-        </GoogleMapHolder>
-      );
-    } else { // ------------ Deprecated ------------
-      const realContainerTagName = (
-        (containerTagName === undefined || containerTagName === null)
-        ? `div`
-        : containerTagName
-      );
-
-      return (
-        <GoogleMapLoader
-          ref="loader"
-          containerElement={React.createElement(realContainerTagName, containerProps)}
-          googleMapElement={
-            <GoogleMap ref="delegate" containerTagName={USE_NEW_BEHAVIOR_TAG_NAME} {...mapProps}>
-              {children}
-            </GoogleMap>
-          }
-        />
-      );
-    }
+    return (
+      <GoogleMapHolder {...this.props}>
+        {this.props.children}
+      </GoogleMapHolder>
+    );
   }
 }

--- a/src/GoogleMapLoader.js
+++ b/src/GoogleMapLoader.js
@@ -7,17 +7,21 @@ import {
 } from "react";
 
 import {
+  default as propTypesElementOfType,
+} from "react-prop-types-element-of-type";
+
+import {
+  default as GoogleMap,
+} from "./GoogleMap";
+
+import {
   default as GoogleMapHolder,
 } from "./creators/GoogleMapHolder";
-
-const USE_NEW_BEHAVIOR_TAG_NAME = `__new_behavior__`;/* CIRCULAR_DEPENDENCY */
 
 export default class GoogleMapLoader extends Component {
   static propTypes = {
     containerElement: PropTypes.node.isRequired,
-    /* CIRCULAR_DEPENDENCY. Uncomment when 5.0.0 comes:
-    propTypesElementOfType(GoogleMap).isRequired, */
-    googleMapElement: PropTypes.element.isRequired,
+    googleMapElement: propTypesElementOfType(GoogleMap).isRequired,
   };
 
   static defaultProps = {
@@ -55,8 +59,6 @@ export default class GoogleMapLoader extends Component {
       //
       return React.cloneElement(this.props.googleMapElement, {
         map: this.state.map,
-        // ------------ Deprecated ------------
-        containerTagName: USE_NEW_BEHAVIOR_TAG_NAME,
       });
     }
   }

--- a/src/addons/MarkerClusterer.js
+++ b/src/addons/MarkerClusterer.js
@@ -107,7 +107,7 @@ export default class MarkerClusterer extends Component {
   render() {
     if (this.state.markerClusterer) {
       return (
-        <MarkerClustererCreator markerClusterer={this.state.markerClusterer} { ...this.props }>
+        <MarkerClustererCreator markerClusterer={this.state.markerClusterer} {...this.props}>
           {this.props.children}
         </MarkerClustererCreator>
       );


### PR DESCRIPTION
## Description

Remove deprecation usage for `<GoogleMap>`. Switch to new behavior `<GoogleMapLoader>`

## Migration

Before:

```js
<GoogleMap containerProps={{
    ...this.props,
    style: {
      height: "100%",
    },
  }}
  ref="map"
  defaultZoom={3}
  defaultCenter={{lat: -25.363882, lng: 131.044922}}
  onClick={::this.handleMapClick}>
  {this.state.markers.map((marker, index) => {
    return (
      <Marker
        {...marker}
        onRightclick={this.handleMarkerRightclick.bind(this, index)} />
    );
  })}
</GoogleMap>
```

After:

```js
<GoogleMapLoader
  containerElement={
    <div
      {...this.props}
      style={{
        height: "100%",
      }}
    />
  }
  googleMapElement={
    <GoogleMap
      ref={(map) => console.log(map)}
      defaultZoom={3}
      defaultCenter={{lat: -25.363882, lng: 131.044922}}
      onClick={::this.handleMapClick}>
      {this.state.markers.map((marker, index) => {
        return (
          <Marker
            {...marker}
            onRightclick={this.handleMarkerRightclick.bind(this, index)} />
        );
      })}
    </GoogleMap>
  }
/>
```