### PR TITLE
fix(info-context): InfoBox/InfoWindow children receive React context (addresses #258)

### DIFF
--- a/src/lib/InfoWindow.js
+++ b/src/lib/InfoWindow.js
@@ -10,7 +10,7 @@ import {
 } from "react";
 
 import {
-  render,
+  unstable_renderSubtreeIntoContainer,
   unmountComponentAtNode,
 } from "react-dom";
 
@@ -71,8 +71,8 @@ const publicMethodMap = {
 };
 
 const controlledPropUpdaterMap = {
-  children(infoWindow, children) {
-    render(Children.only(children), infoWindow.getContent());
+  children(infoWindow, children, component) {
+    unstable_renderSubtreeIntoContainer(component, Children.only(children), infoWindow.getContent());
   },
   options(infoWindow, options) { infoWindow.setOptions(options); },
   position(infoWindow, position) { infoWindow.setPosition(position); },
@@ -135,7 +135,7 @@ export default _.flowRight(
 
   componentDidMount() {
     const infoWindow = getInstanceFromComponent(this);
-    controlledPropUpdaterMap.children(infoWindow, this.props.children);
+    controlledPropUpdaterMap.children(infoWindow, this.props.children, this);
   },
 
   componentWillReceiveProps(nextProps, nextContext) {

--- a/src/lib/addons/InfoBox.js
+++ b/src/lib/addons/InfoBox.js
@@ -9,7 +9,7 @@ import {
 } from "react";
 
 import {
-  render,
+  unstable_renderSubtreeIntoContainer,
 } from "react-dom";
 
 import {
@@ -65,8 +65,8 @@ const publicMethodMap = {
 };
 
 const controlledPropUpdaterMap = {
-  children(infoWindow, children) {
-    render(Children.only(children), infoWindow.getContent());
+  children(infoWindow, children, component) {
+    unstable_renderSubtreeIntoContainer(component, Children.only(children), infoWindow.getContent());
   },
   options(infoBox, options) { infoBox.setOptions(options); },
   position(infoBox, position) { infoBox.setPosition(position); },
@@ -142,7 +142,7 @@ export default _.flowRight(
 
   componentDidMount() {
     const infoBox = getInstanceFromComponent(this);
-    controlledPropUpdaterMap.children(infoBox, this.props.children);
+    controlledPropUpdaterMap.children(infoBox, this.props.children, this);
   },
 
   componentWillReceiveProps(nextProps, nextContext) {

--- a/src/lib/enhanceElement.js
+++ b/src/lib/enhanceElement.js
@@ -87,7 +87,7 @@ const enhanceWithPropTypes = _.curry((
       _.forEach(controlledPropUpdaterMap, (fn, key) => {
         const nextValue = this.props[key];
         if (nextValue !== prevProps[key]) {
-          fn(getInstanceFromComponent(this), nextValue);
+          fn(getInstanceFromComponent(this), nextValue, this);
         }
       });
       componentDidUpdate.call(this, prevProps, prevState);


### PR DESCRIPTION
Now in `InfoWindow` or `InfoBox` children you can use components like React Router's `Link`, which relies on React context for route matching information. Addresses #258.

ETA: For this to work all prop updater functions from a component's `controlledPropUpdaterMap` are called from `enhanceElement` with a supplied `this` (via `Function.prototype.call`). See [here](https://github.com/tomchentw/react-google-maps/pull/361/files#diff-8b3b61db2ea6af52ddd66b61ca5494ffR90). This wasn't necessary before since none of the updaters required `this`, but we need `this` in order to get React context.