### PR TITLE
fix(HeatmapLayer): HeatmapLayer constructor fix

### DIFF
--- a/src/lib/HeatmapLayer.js
+++ b/src/lib/HeatmapLayer.js
@@ -74,7 +74,7 @@ export default _.flowRight(
 
   getInitialState() {
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#HeatmapLayer
-    const heatmapLayer = new google.maps.HeatmapLayer({
+    const heatmapLayer = new google.maps.visualization.HeatmapLayer({
       map: this.context[MAP],
       ...collectUncontrolledAndControlledProps(
         defaultUncontrolledPropTypes,


### PR DESCRIPTION
HeatmapLayer should use google.maps.visualization.HeatmapLayer() as the constructor. See here for more information: https://developers.google.com/maps/documentation/javascript/3.exp/reference#HeatmapLayer.

#375