### PR TITLE
[Marker] Prevent Marker from redrawing MarkerClusterer when being added / removed

### DIFF
--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -236,7 +236,7 @@ exports.default = (0, _flowRight3.default)(_react2.default.createClass, (0, _enh
     var marker = new google.maps.Marker((0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props));
     var markerClusterer = this.context[_constants.MARKER_CLUSTERER];
     if (markerClusterer) {
-      markerClusterer.addMarker(marker);
+      markerClusterer.addMarker(marker, true);
     } else {
       marker.setMap(this.context[_constants.MAP]);
     }
@@ -250,7 +250,7 @@ exports.default = (0, _flowRight3.default)(_react2.default.createClass, (0, _enh
     if (marker) {
       var markerClusterer = this.context[_constants.MARKER_CLUSTERER];
       if (markerClusterer) {
-        markerClusterer.removeMarker(marker);
+        markerClusterer.removeMarker(marker, true);
       }
       marker.setMap(null);
     }

--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -54,6 +54,8 @@ var controlledPropTypes = {
 
   label: _react.PropTypes.any,
 
+  noRedraw: _react.PropTypes.bool,
+
   opacity: _react.PropTypes.number,
 
   options: _react.PropTypes.object,
@@ -236,7 +238,7 @@ exports.default = (0, _flowRight3.default)(_react2.default.createClass, (0, _enh
     var marker = new google.maps.Marker((0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props));
     var markerClusterer = this.context[_constants.MARKER_CLUSTERER];
     if (markerClusterer) {
-      markerClusterer.addMarker(marker, true);
+      markerClusterer.addMarker(marker, !!this.props.noRedraw);
     } else {
       marker.setMap(this.context[_constants.MAP]);
     }
@@ -250,7 +252,7 @@ exports.default = (0, _flowRight3.default)(_react2.default.createClass, (0, _enh
     if (marker) {
       var markerClusterer = this.context[_constants.MARKER_CLUSTERER];
       if (markerClusterer) {
-        markerClusterer.removeMarker(marker, true);
+        markerClusterer.removeMarker(marker, !!this.props.noRedraw);
       }
       marker.setMap(null);
     }

--- a/src/lib/Marker.js
+++ b/src/lib/Marker.js
@@ -42,6 +42,8 @@ const controlledPropTypes = {
 
   label: PropTypes.any,
 
+  noRedraw: PropTypes.bool,
+
   opacity: PropTypes.number,
 
   options: PropTypes.object,
@@ -211,7 +213,7 @@ export default _.flowRight(
     );
     const markerClusterer = this.context[MARKER_CLUSTERER];
     if (markerClusterer) {
-      markerClusterer.addMarker(marker, true);
+      markerClusterer.addMarker(marker, !!this.props.noRedraw);
     } else {
       marker.setMap(this.context[MAP]);
     }
@@ -231,7 +233,7 @@ export default _.flowRight(
     if (marker) {
       const markerClusterer = this.context[MARKER_CLUSTERER];
       if (markerClusterer) {
-        markerClusterer.removeMarker(marker, true);
+        markerClusterer.removeMarker(marker, !!this.props.noRedraw);
       }
       marker.setMap(null);
     }

--- a/src/lib/Marker.js
+++ b/src/lib/Marker.js
@@ -211,7 +211,7 @@ export default _.flowRight(
     );
     const markerClusterer = this.context[MARKER_CLUSTERER];
     if (markerClusterer) {
-      markerClusterer.addMarker(marker);
+      markerClusterer.addMarker(marker, true);
     } else {
       marker.setMap(this.context[MAP]);
     }
@@ -231,7 +231,7 @@ export default _.flowRight(
     if (marker) {
       const markerClusterer = this.context[MARKER_CLUSTERER];
       if (markerClusterer) {
-        markerClusterer.removeMarker(marker);
+        markerClusterer.removeMarker(marker, true);
       }
       marker.setMap(null);
     }


### PR DESCRIPTION
Hello,
I'm trying to solve this issue: https://github.com/tomchentw/react-google-maps/issues/395

The idea is to prevent Marker from redrawing MarkerClusterer when being added / removed using `markerclustererplus` noredraw option.

The current implementation adds `noRedraw` to `Marker` props, but I believe it bypasses a potential `defaultNoRedraw`.