### PR TITLE
Unmounting an InfoBox removes all listeners.

### DIFF
--- a/src/lib/addons/InfoBox.js
+++ b/src/lib/addons/InfoBox.js
@@ -156,7 +156,7 @@ export default _.flowRight(
   componentWillUnmount() {
     const infoBox = getInstanceFromComponent(this);
     if (infoBox) {
-      infoBox.setMap(null);
+      infoBox.close();
     }
   },
 


### PR DESCRIPTION
Hi, 

I want to address an obscure issue that arises from failing to clean up InfoBox listeners on unmount. Taking a look at the end of the file here: https://github.com/googlemaps/v3-utility-library/blob/master/infobox/src/infobox.js it seems there's more to do than simple `setMap(null)` in order to remove `InfoBox` from the map. In particular, all the listeners should be cleaned up. Perhaps calling `infoBox.close()` on unmounting makes more sense here?
