### PR TITLE
Adding Options to Kml Layer

### DIFF
--- a/lib/KmlLayer.js
+++ b/lib/KmlLayer.js
@@ -38,6 +38,7 @@ var controlledPropTypes = {
   //
   // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
   defaultViewport: _react.PropTypes.any,
+  options: _react.PropTypes.any,
   metadata: _react.PropTypes.any,
   status: _react.PropTypes.any,
   url: _react.PropTypes.string,
@@ -70,6 +71,9 @@ var publicMethodMap = {
   getMetadata: function getMetadata(kmlLayer) {
     return kmlLayer.getMetadata();
   },
+  getOptions: function getOptions(kmlLayer) {
+    return kmlLayer.getOptions();
+  },
   getStatus: function getStatus(kmlLayer) {
     return kmlLayer.getStatus();
   },
@@ -87,6 +91,9 @@ var controlledPropUpdaterMap = {
   },
   metadata: function metadata(kmlLayer, _metadata) {
     kmlLayer.setMetadata(_metadata);
+  },
+  options: function options(kmlLayer, _options) {
+    kmlLayer.setOptions(_options);
   },
   status: function status(kmlLayer, _status) {
     kmlLayer.setStatus(_status);

--- a/src/lib/KmlLayer.js
+++ b/src/lib/KmlLayer.js
@@ -27,6 +27,7 @@ const controlledPropTypes = {
   //
   // https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayer
   defaultViewport: PropTypes.any,
+  options: PropTypes.any,
   metadata: PropTypes.any,
   status: PropTypes.any,
   url: PropTypes.string,
@@ -56,6 +57,8 @@ const publicMethodMap = {
 
   getMetadata(kmlLayer) { return kmlLayer.getMetadata(); },
 
+  getOptions(kmlLayer) { return kmlLayer.getOptions(); },
+
   getStatus(kmlLayer) { return kmlLayer.getStatus(); },
 
   getUrl(kmlLayer) { return kmlLayer.getUrl(); },
@@ -67,6 +70,7 @@ const publicMethodMap = {
 const controlledPropUpdaterMap = {
   defaultViewport(kmlLayer, defaultViewport) { kmlLayer.setDefaultViewport(defaultViewport); },
   metadata(kmlLayer, metadata) { kmlLayer.setMetadata(metadata); },
+  options(kmlLayer, options) { kmlLayer.setOptions(options); },
   status(kmlLayer, status) { kmlLayer.setStatus(status); },
   url(kmlLayer, url) { kmlLayer.setUrl(url); },
   zIndex(kmlLayer, zIndex) { kmlLayer.setZIndex(zIndex); },


### PR DESCRIPTION
Allows user to pass an object of options to a Kml Layer. Options can be viewed here: https://developers.google.com/maps/documentation/javascript/3.exp/reference#KmlLayerOptions

This pull request also addresses #406 