### PR TITLE
Fix jank in large infoWindows

### DIFF
--- a/src/lib/InfoWindow.js
+++ b/src/lib/InfoWindow.js
@@ -116,8 +116,6 @@ export default _.flowRight(
 
   getInitialState() {
     const map = this.context[MAP];
-    const div = document.createElement(`div`);
-    render(this.props.children, div);
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#InfoWindow
     const infoWindow = new google.maps.InfoWindow({
       map,
@@ -126,7 +124,6 @@ export default _.flowRight(
         controlledPropTypes,
         this.props
       ),
-      content: div,
       // Override props of ReactElement type
       children: undefined,
     });
@@ -138,7 +135,12 @@ export default _.flowRight(
   },
 
   componentDidMount() {
+    const div = document.createElement(`div`);
+    render(this.props.children, div);
+
     const infoWindow = getInstanceFromComponent(this);
+    infoWindow.setContent(div);
+
     controlledPropUpdaterMap.children(infoWindow, this.props.children, this);
   },
 

--- a/src/lib/InfoWindow.js
+++ b/src/lib/InfoWindow.js
@@ -12,6 +12,7 @@ import {
 import {
   unstable_renderSubtreeIntoContainer,
   unmountComponentAtNode,
+  render,
 } from "react-dom";
 
 import {
@@ -115,6 +116,8 @@ export default _.flowRight(
 
   getInitialState() {
     const map = this.context[MAP];
+    const div = document.createElement(`div`);
+    render(this.props.children, div);
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#InfoWindow
     const infoWindow = new google.maps.InfoWindow({
       map,
@@ -123,10 +126,11 @@ export default _.flowRight(
         controlledPropTypes,
         this.props
       ),
+      content: div,
       // Override props of ReactElement type
-      content: document.createElement(`div`),
       children: undefined,
     });
+
     openInfoWindow(this.context, infoWindow);
     return {
       [INFO_WINDOW]: infoWindow,


### PR DESCRIPTION
This fixes an issue that several people (including myself) were having (https://github.com/tomchentw/react-google-maps/issues/444 https://github.com/tomchentw/react-google-maps/issues/408). Large info windows would flicker underneath the infoWindow because an div was added to the infoWindow content before actually rendering the infowindow content. This renders the child component to the div before giving it to the infoWindow.

I'm not sure if this is the best solution but it worked for my purposes. Open to any other suggestions.