### PR TITLE
Exposing public APIs for use in code

### DIFF
--- a/src/lib/GoogleMap.js
+++ b/src/lib/GoogleMap.js
@@ -128,6 +128,20 @@ const publicMethodMap = {
   panTo(map, args) { return map.panTo(...args); },
 
   panToBounds(map, args) { return map.panToBounds(...args); },
+
+  setCenter(map, args) { return map.setCenter(...args); },
+
+  setHeading(map, args) { return map.setHeading(...args); },
+
+  setMapTypeId(map, args) { return map.setMapTypeId(...args); },
+
+  setOptions(map, args) { return map.setOptions(...args); },
+
+  setStreetView(map, args) { return map.setStreetView(...args); },
+
+  setTilt(map, args) { return map.setTilt(...args); },
+
+  setZoom(map, args) { return map.setZoom(...args); },
   // END - Public APIs - Use this carefully
 };
 


### PR DESCRIPTION
I've found that the set-zoom-in-prop way of programmatically changing zoom doesn't work if you've called map.fitBounds(). The map is no longer responsive to zoom or center changes. This exposes setZoom, setCenter, etc, and allows for continued programmatic map manipulations.