### PR TITLE
Refactor/relocate heatmap layer

### DIFF
--- a/src/lib/HeatmapLayer.js
+++ b/src/lib/HeatmapLayer.js
@@ -1,0 +1,2 @@
+// Provides backward compatibility. Will remove in 7.0.0
+export default from "./visualization/HeatmapLayer"

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -35,8 +35,9 @@ export {
 } from "./DirectionsRenderer";
 
 export {
+  // Provides backward compatibility. Will remove in 7.0.0
   default as HeatmapLayer,
-} from "./HeatmapLayer";
+} from "./visualization/HeatmapLayer";
 
 export {
   default as InfoWindow,

--- a/src/lib/visualization/HeatmapLayer.js
+++ b/src/lib/visualization/HeatmapLayer.js
@@ -9,13 +9,13 @@ import {
 import {
   MAP,
   HEATMAP_LAYER,
-} from "./constants";
+} from "../constants";
 
 import {
   addDefaultPrefixToPropTypes,
   collectUncontrolledAndControlledProps,
   default as enhanceElement,
-} from "./enhanceElement";
+} from "../enhanceElement";
 
 const controlledPropTypes = {
   // NOTICE!!!!!!

--- a/src/lib/visualization/__tests__/index.test.js
+++ b/src/lib/visualization/__tests__/index.test.js
@@ -1,0 +1,9 @@
+import HeatmapLayer from "../HeatmapLayer";
+
+describe(`visualization`, () => {
+  describe(`HeatmapLayer`, () => {
+    it(`should be exported`, () => {
+      expect(HeatmapLayer).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Put `HeatmapLayer` into `visualization` namespace but still provides backward compatibility in the top-level exports.

We encourage switching the import statement to:

```js
import HeatmapLayer from "react-google-maps/lib/visualization/HeatmapLayer";
```