### PR TITLE
allow for label class on marker

### DIFF
--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -78,7 +78,9 @@ var controlledPropTypes = {
 
   visible: _propTypes2.default.bool,
 
-  zIndex: _propTypes2.default.number
+  zIndex: _propTypes2.default.number,
+
+  markerClass: _propTypes2.default.any
 };
 
 var defaultUncontrolledPropTypes = (0, _enhanceElement.addDefaultPrefixToPropTypes)(controlledPropTypes);
@@ -243,7 +245,8 @@ exports.default = (0, _flowRight3.default)(_createReactClass2.default, (0, _enha
 
   getInitialState: function getInitialState() {
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Marker
-    var marker = new google.maps.Marker((0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props));
+    var Marker = this.props.markerClass || google.maps.Marker;
+    var marker = new Marker((0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props));
     var markerClusterer = this.context[_constants.MARKER_CLUSTERER];
     if (markerClusterer) {
       markerClusterer.addMarker(marker, !!this.props.noRedraw);

--- a/src/lib/Marker.js
+++ b/src/lib/Marker.js
@@ -60,6 +60,8 @@ const controlledPropTypes = {
   visible: PropTypes.bool,
 
   zIndex: PropTypes.number,
+
+  markerClass: PropTypes.any,
 };
 
 const defaultUncontrolledPropTypes = addDefaultPrefixToPropTypes(controlledPropTypes);
@@ -205,7 +207,8 @@ export default _.flowRight(
 
   getInitialState() {
     // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Marker
-    const marker = new google.maps.Marker(
+    const Marker = this.props.markerClass || google.maps.Marker;
+    const marker = new Marker(
       collectUncontrolledAndControlledProps(
         defaultUncontrolledPropTypes,
         controlledPropTypes,


### PR DESCRIPTION
Transform your label into your own custom marker using css!
no more overlays! 🎊 🎊 🎊 

First add the makerwithlabel script to your html file:
`<script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=geometry,drawing,places&key=AIzaSyCPnwKkjPSZ6YaOnRrybSYyW8t1yplLNFs">
  </script>`
From there you can modify your Marker to take in a labelClass as an option:
(You can also add opacity: 0 if you want to completely hide the pin and use the label as a marker)
```
marker = [{
        position: {
          lat: 37.0902,
          lng: -95.7129
        },
        key: id,
        opacity: 0,
        options: {
          labelClass: styles.customPacmanMarker,
          labelAnchor: new google.maps.Point(16, 12)
        },
        markerClass={window.MarkerWithLabel}
}]
```
Then add your styles and you got yourself a custom css marker:
```
.customPacmanMarker {
  width: 0px;
  height: 0px;
  border-right: 15px solid transparent;
  border-top: 15px solid yellow;
  border-left: 15px solid yellow;
  border-bottom: 15px solid yellow;
  border-top-left-radius: 15px;
  border-top-right-radius: 15px;
  border-bottom-left-radius: 15px;
  border-bottom-right-radius: 15px;
}

```

![image](https://cloud.githubusercontent.com/assets/8698365/26259005/4f4e37d6-3c84-11e7-8712-7dafbc6cdf2f.png)

