### PR TITLE
Added the availability to auto-zoom on places

### DIFF
--- a/src/app/pages/places/SearchBoxExample.js
+++ b/src/app/pages/places/SearchBoxExample.js
@@ -87,6 +87,12 @@ export default class SearchBoxExample extends Component {
   handlePlacesChanged() {
     const places = this._searchBox.getPlaces();
 
+    const bounds = new google.maps.LatLngBounds(); //creating new bounds for the place returned from search
+
+    places.map(place => {
+      place.geometry.viewport ? bounds.union(place.geometry.viewport) : bounds.extend(place.geometry.location)
+    }); //parsing returned places and getting the bounds
+
     // Add a marker for each place returned from search bar
     const markers = places.map(place => ({
       position: place.geometry.location,
@@ -99,6 +105,8 @@ export default class SearchBoxExample extends Component {
       center: mapCenter,
       markers,
     });
+
+    this._map.fitBounds(bounds); //making map zoom in on the selected location
   }
 
   render() {

--- a/src/app/pages/places/SearchBoxExample.js
+++ b/src/app/pages/places/SearchBoxExample.js
@@ -87,18 +87,16 @@ export default class SearchBoxExample extends Component {
   handlePlacesChanged() {
     const places = this._searchBox.getPlaces();
 
-    const bounds = new google.maps.LatLngBounds(); //creating new bounds for the place returned from search
+    const bounds = new google.maps.LatLngBounds();
 
     places.map(place => {
       place.geometry.viewport ? bounds.union(place.geometry.viewport) : bounds.extend(place.geometry.location)
-    }); //parsing returned places and getting the bounds
+    });
 
-    // Add a marker for each place returned from search bar
     const markers = places.map(place => ({
       position: place.geometry.location,
     }));
 
-    // Set markers; set map center to first search result
     const mapCenter = markers.length > 0 ? markers[0].position : this.state.center;
 
     this.setState({
@@ -106,7 +104,7 @@ export default class SearchBoxExample extends Component {
       markers,
     });
 
-    this._map.fitBounds(bounds); //making map zoom in on the selected location
+    this._map.fitBounds(bounds);
   }
 
   render() {


### PR DESCRIPTION
When implementing maps with searchbox for my project, I faced the problem with map not auto-zooming on searched places. Say if I have a default zoom of 10 over my town, but when I search for a specific place, map keeps zoom at 10 which didn't work for me. 

Therefore, I have added new bounds for the searched places within handlePlacesChanged() handler and forced the map to zoom in with fitBounds(bounds)

I didn't find this solution in any FAQ thread, so thought it might be useful. Thanks for your project and forgive if I submitted this change incorrectly - I'm a git newbie!