### PR TITLE
Feature/fusion table multiple empty map fix

### DIFF
--- a/lib/FusionTablesLayer.js
+++ b/lib/FusionTablesLayer.js
@@ -82,7 +82,8 @@ exports.default = (0, _flowRight3.default)(_createReactClass2.default, (0, _enha
 
     getInitialState: function getInitialState() {
         var fusionTablesLayer = new google.maps.FusionTablesLayer((0, _extends3.default)({
-            map: this.context[_constants.MAP]
+            map: this.context[_constants.MAP],
+            query: this.props.options.query
         }, (0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props)));
 
         return (0, _defineProperty3.default)({}, _constants.FUSION_TABLES_LAYER, fusionTablesLayer);

--- a/lib/FusionTablesLayer.js
+++ b/lib/FusionTablesLayer.js
@@ -82,8 +82,7 @@ exports.default = (0, _flowRight3.default)(_createReactClass2.default, (0, _enha
 
     getInitialState: function getInitialState() {
         var fusionTablesLayer = new google.maps.FusionTablesLayer((0, _extends3.default)({
-            map: this.context[_constants.MAP],
-            query: this.props.options.query
+            map: this.context[_constants.MAP]
         }, (0, _enhanceElement.collectUncontrolledAndControlledProps)(defaultUncontrolledPropTypes, controlledPropTypes, this.props)));
 
         return (0, _defineProperty3.default)({}, _constants.FUSION_TABLES_LAYER, fusionTablesLayer);

--- a/src/lib/FusionTablesLayer.js
+++ b/src/lib/FusionTablesLayer.js
@@ -72,6 +72,7 @@ export default _.flowRight(
     getInitialState() {
         const fusionTablesLayer = new google.maps.FusionTablesLayer({
             map: this.context[MAP],
+            query: this.props.options.query,
             ...collectUncontrolledAndControlledProps(
                 defaultUncontrolledPropTypes,
                 controlledPropTypes,


### PR DESCRIPTION
Fusion Table Layer needs the query prop in the option we're passing to `new google.maps.FusionTablesLayer`, otherwise, it works only at the first time, meaning that if you have a client side router (like react-router) it won't work if you leave the page where the map is located and go back (the map will be empty)