### PR TITLE
docs: addon imports should be named imports

### DIFF
--- a/src/components/addons/InfoBox.md
+++ b/src/components/addons/InfoBox.md
@@ -7,7 +7,7 @@ import {
   withGoogleMap,
   GoogleMap,
 } from "react-google-maps";
-import InfoBox from "react-google-maps/lib/components/addons/InfoBox";
+import { InfoBox } from "react-google-maps/lib/components/addons/InfoBox";
 import demoFancyMapStyles from "./demoFancyMapStyles.json";
 
 const StyledMapWithAnInfoBox = compose(

--- a/src/components/addons/MarkerClusterer.md
+++ b/src/components/addons/MarkerClusterer.md
@@ -10,7 +10,7 @@ import {
   Marker,
 } from "react-google-maps";
 
-import MarkerClusterer from "react-google-maps/lib/components/addons/MarkerClusterer";
+import { MarkerClusterer } from "react-google-maps/lib/components/addons/MarkerClusterer";
 
 const MapWithAMarkerClusterer = compose(
   withProps({


### PR DESCRIPTION
This PR adds minor fixes to docs mentioned in issue #610. 

Imports on InfoBox and MarkerClusterer examples should be named imports.