### PR TITLE
Fix eslint configuration.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,6 @@
     "prettier"
   ],
   "rules": {
-    "prettier/prettier": ["warn"]
+    "prettier/prettier": ["warn", { "semi": false, "trailingComma": "es5" }]
   }
 }


### PR DESCRIPTION
Currently running `npm run lint` results in many semicolon and trailing comma warnings.
Adding options for eslint prettier plugin solves this.