### PR TITLE
Added function to access MapTypeRegistry

### DIFF
--- a/src/macros/GoogleMap.jsx
+++ b/src/macros/GoogleMap.jsx
@@ -34,6 +34,12 @@ export class Map extends React.PureComponent {
 
   static propTypes = {
     __jscodeshiftPlaceholder__: null,
+
+    /**
+     * @url https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapTypeRegistry
+     * @type Array<[id:string, mapType:MapType|*]>
+     */
+    defaultExtraMapTypes: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)),
   }
 
   static contextTypes = {
@@ -108,4 +114,8 @@ export default Map
 
 const eventMap = {}
 
-const updaterMap = {}
+const updaterMap = {
+  extraMapTypes(instance, extra) {
+    extra.forEach(it => instance.mapTypes.set(...it))
+  },
+}


### PR DESCRIPTION
This change allows users to access the [`mapTypes.set`](https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapTypeRegistry) property without using the secret context property.

Adds a new method `map.addMapType` - let me know if this isn't close enough to the Google Maps API - something like `map.mapTypesSet` might me more inline with API reference.

### Use Case

Allow a map style to only apply to one map type. Below, I'm replacing the road map with custom styles and leaving the satellite view as default.

```js
import React from 'react';
import { GoogleMap, withGoogleMap, withScriptjs } from 'react-google-maps';
import mapStyles from './mapStyles';

const Map = withScriptjs(withGoogleMap(props => {
    const handleMapLoad = map => {
        if(map) {
            const styledRoadmap = new google.maps.StyledMapType(
                mapStyles,
                { name: 'Map' }
            );
            map.addMapType('styled_roadmap', styledRoadmap);
        }
    };

    return (
        <GoogleMap
            defaultOptions={{
                mapTypeId: 'styled_roadmap',
                mapTypeControlOptions: {
                    mapTypeIds: ['styled_roadmap', 'satellite']
                }
            }}
            ref={handleMapLoad}
        >
            {props.children}
        </GoogleMap>
    );
}));

export default Map;
```

I think this would be worth documenting on the docs site, let me know if that would be a useful addition to this PR.