### PR TITLE
feat(places/SearchBox): allow other elements around SearchBox input

### DIFF
--- a/src/macros/places/SearchBox.jsx
+++ b/src/macros/places/SearchBox.jsx
@@ -110,7 +110,7 @@ export class SearchBox extends React.PureComponent {
      * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#SearchBox
      */
     const searchBox = new google.maps.places.SearchBox(
-      this.containerElement.firstChild
+      this.containerElement.querySelector('input')
     )
     construct(SearchBox.propTypes, updaterMap, this.props, searchBox)
     this.setState({


### PR DESCRIPTION
This tiny change allows having other elements around `input` when defining `<SearchBox />`:

```js
<SearchBox>
  <div className={styles.searchBox}>
    <input className={styles.searchInput} type="text" />
    {isSearching && (
      <button className={styles.clearSearchButton} type="button" onClick={this.clearSearch}>
        Clear
      </button>
    )}
  </div>
</SearchBox>
```