### PR TITLE
fix(InfoWindow): do not remove container element on mount

### DIFF
--- a/src/macros/InfoWindow.jsx
+++ b/src/macros/InfoWindow.jsx
@@ -67,7 +67,6 @@ export class InfoWindow extends React.PureComponent {
     if (React.version.match(/^16/)) {
       this.state[INFO_WINDOW].setContent(this.containerElement)
       open(this.state[INFO_WINDOW], this.context[ANCHOR])
-      this.containerElement = undefined
       return
     }
     const content = document.createElement(`div`)


### PR DESCRIPTION
`6a61f2c` updated `InfoWindow` to support React@^16.
Unfortunately, prior to this commit, when re-rendering is
triggered from the parent (e.g. due to a state change) without
requiring re-mounting, the following error is returned:

	Invariant Violation Target container is not a DOM element

The above error was caused by `this.containerElement` being set
to undefined after the component mounts. Consequently, when
`render()` is called again, it would fail. If we are always
re-mounting the `InfoWindow` component, the aforementioned error
will not occur.

For example:

```
<Marker position={{ lat: -34.397, lng: 150.644 }}>
    {showInfoWindow ? (<InfoWindow>
        <div>Hello World!</div>
    </InfoWindow>) : null}
</Marker>
```

The above code will result in `InfoWindow` re-mounting when
re-rendering (e.g. when `showInfoWindow` changes from given props
or from the state).

```
<Marker position={{ lat: -34.397, lng: 150.644 }}>
    <InfoWindow>
        <div>Hello World!</div>
    </InfoWindow>
</Marker>
```

The above code will throw an error if the encapsulating `render()`
method is called multiple times. Again, it is because we are not
re-mounting, and because `render()` is not idempotent in the
sense that the container element reference is removed after use
(or rather, mount).

---

Closes #696

---

_I'm not sure if it (the `undefined`) was added for a good, and indisputable reason._

---

## PLEASE CHECK "Allow edits from maintainers"

![help](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits.png)

## FOLLOW "Conventional Commits Specification" FOR ALL COMMITS

https://conventionalcommits.org/
