### PR TITLE
fix(InfoWindow): Editting macros file for React 16

### DIFF
--- a/src/macros/InfoWindow.jsx
+++ b/src/macros/InfoWindow.jsx
@@ -67,7 +67,6 @@ export class InfoWindow extends React.PureComponent {
     if (React.version.match(/^16/)) {
       this.state[INFO_WINDOW].setContent(this.containerElement)
       open(this.state[INFO_WINDOW], this.context[ANCHOR])
-      this.containerElement = undefined
       return
     }
     const content = document.createElement(`div`)


### PR DESCRIPTION
I did the same changes to the code as they were proposed on [#699](https://github.com/tomchentw/react-google-maps/pull/699), because someone in the comments said this file is autogenerated from `macros/InfoWindow.jsx`

## PLEASE CHECK "Allow edits from maintainers"

![help](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits.png)

## FOLLOW "Conventional Commits Specification" FOR ALL COMMITS

https://conventionalcommits.org/
