### PR TITLE
feat(StandaloneSearchBox): Accept wrapped input

### DIFF
--- a/src/macros/places/StandaloneSearchBox.jsx
+++ b/src/macros/places/StandaloneSearchBox.jsx
@@ -44,7 +44,9 @@ class SearchBox extends React.PureComponent {
     /*
      * @see https://developers.google.com/maps/documentation/javascript/3.exp/reference#SearchBox
      */
-    const searchBox = new google.maps.places.SearchBox(element)
+    const searchBox = new google.maps.places.SearchBox(
+      element.querySelector('input') || element
+    )
     construct(SearchBox.propTypes, updaterMap, this.props, searchBox)
 
     componentDidMount(this, searchBox, eventMap)


### PR DESCRIPTION
`StandaloneSearchBox` searches for an input element inside itself to pass to `google.maps.places.SearchBox`. If no such element is found it defaults to itself.

Closes #708 