### PR TITLE
fix(places/SearchBox): undefined child at unmount

### DIFF
--- a/src/macros/places/SearchBox.jsx
+++ b/src/macros/places/SearchBox.jsx
@@ -145,7 +145,9 @@ export class SearchBox extends React.PureComponent {
       const child = this.context[MAP].controls[
         this.props.controlPosition
       ].removeAt(this.mountControlIndex)
-      this.containerElement.appendChild(child)
+      if(child !== undefined){
+        this.containerElement.appendChild(child)
+      }
     }
   }
 


### PR DESCRIPTION
Google Maps Api error can cause removal of searchBox which can results into an error at unmount while trying to append undefined to containerElement
