### PR TITLE
Remove type definitions from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,9 +112,6 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "@types/googlemaps": "^3.0.0",
-    "@types/markerclustererplus": "^2.1.29",
-    "@types/react": "^15.0.0 || ^16.0.0",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
   },


### PR DESCRIPTION
Typing dependencies don't have much sense for those who use Flowtype or no typing at all.
