### PR TITLE
Fix backgroundColor of map tiles #764.

### DIFF
--- a/src/withGoogleMap.jsx
+++ b/src/withGoogleMap.jsx
@@ -56,7 +56,7 @@ export function withGoogleMap(BaseComponent) {
  See https://github.com/tomchentw/react-google-maps/pull/168`
       )
       // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
-      const map = new google.maps.Map(node)
+      const map = new google.maps.Map(node, this.props.defaultOptions)
       this.setState({ map })
     }
 


### PR DESCRIPTION
Passing `defaultOptions={backgroundColor: "black"}` to GoogleMap component did not have any effect, therefore I added an option to pass `defaultOptions` as props directly to the component returned from withGoogleMap function.