### PR TITLE
fix(types/index.d.ts): include padding parameter in fitBounds call signature

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -258,7 +258,7 @@ declare module 'react-google-maps/lib/components/GoogleMap' {
     }
 
     export default class GoogleMap extends Component<GoogleMapProps> {
-        fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral): void
+        fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number): void
         panBy(x: number, y: number): void
         panTo(latLng: google.maps.LatLng | google.maps.LatLngLiteral): void
         panToBounds(latLngBounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral): void


### PR DESCRIPTION
As per https://developers.google.com/maps/documentation/javascript/reference . Noticed it when rewriting one of the components to TypeScript lighted up all the usages of this method. 