### PR TITLE
add typings for defaultExtraMapTypes

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -219,6 +219,7 @@ declare module 'react-google-maps/lib/components/GoogleMap' {
     import { Component } from 'react'
 
     export interface GoogleMapProps {
+        defaultExtraMapTypes?: [string, google.maps.MapType][]
         defaultCenter?: google.maps.LatLng | google.maps.LatLngLiteral
         defaultClickableIcons?: boolean
         defaultHeading?: number


### PR DESCRIPTION
The typings wasn't exposed and I cannot use it inside my component.