### PR TITLE
fix(tx): fix "destructure non-iterable instance" error on CI builds

### DIFF
--- a/src/tx/ClassDefinition.js
+++ b/src/tx/ClassDefinition.js
@@ -1,4 +1,3 @@
-import { parse } from "url"
 import toMarkdown from "to-markdown"
 import makeFetchHappen from "make-fetch-happen"
 import cheerio from "cheerio"
@@ -33,7 +32,7 @@ function contentToJS(KlassName, $, $content) {
   const $constructorTable = $content.find(
     `[summary="class ${KlassName} - Constructor"]`
   )
-  const [, constructorArgs] = $constructorTable
+  const constructorArgs = $constructorTable
     .find(`tr > td > code`)
     .text()
     .match(/\S+\((.*)\)/)


### PR DESCRIPTION
Fix for "TypeError: Invalid attempt to destructure non-iterable instance" error on CI builds (Travis/Netlify).