### PR TITLE
Update markerwithlabel version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "invariant": "^2.2.1",
     "lodash": "^4.16.2",
     "marker-clusterer-plus": "^2.1.4",
-    "markerwithlabel": "^2.0.1",
+    "markerwithlabel": "^2.0.2",
     "prop-types": "^15.5.8",
     "recompose": "^0.26.0",
     "scriptjs": "^2.5.8",


### PR DESCRIPTION
Solves "can't read property removeChild" of null" caused by markerwithlabel
