### PR TITLE
fix: markerwithlabel version upgrade to fix onRemove validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "invariant": "^2.2.1",
     "lodash": "^4.16.2",
     "marker-clusterer-plus": "^2.1.4",
-    "markerwithlabel": "^2.0.1",
+    "markerwithlabel": "^2.0.2",
     "prop-types": "^15.5.8",
     "recompose": "^0.26.0",
     "scriptjs": "^2.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5564,9 +5564,9 @@ marker-clusterer-plus@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz#f8eff74d599dab3b7d0e3fed5264ea0e704f5d67"
 
-markerwithlabel@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/markerwithlabel/-/markerwithlabel-2.0.1.tgz#822f4eb68c488c2509c5ebdb75982eb84a856096"
+markerwithlabel@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/markerwithlabel/-/markerwithlabel-2.0.2.tgz#fa6aee4abb0ee553e24e2b708226858f58b8729e"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"


### PR DESCRIPTION
in previous version 2.0.1 of **markerwithlabel**, there were no validations added while unmounting the markerwithlabel. They have released a new version 2.0.2 to fix the issue. I have upgraded the dependency and checked all reflected changes in node modules. Please review it as I'm also currently using it my app and app crashes while **markerwithlabel** gets unmounted.
