### PR TITLE
feat(types): add optional padding parameter to fitBounds method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -258,7 +258,7 @@ declare module 'react-google-maps/lib/components/GoogleMap' {
     }
 
     export default class GoogleMap extends Component<GoogleMapProps> {
-        fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral): void
+        fitBounds(bounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral, padding?: number | google.maps.Padding): void
         panBy(x: number, y: number): void
         panTo(latLng: google.maps.LatLng | google.maps.LatLngLiteral): void
         panToBounds(latLngBounds: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral): void


### PR DESCRIPTION
`fitBounds` methods now supports an optional `padding` parameter.

https://developers.google.com/maps/documentation/javascript/reference/map#Map.fitBounds