### PR TITLE
feat: Update EventListener to pass mouse event to callback function

### DIFF
--- a/src/utils/MapChildHelper.js
+++ b/src/utils/MapChildHelper.js
@@ -70,7 +70,9 @@ function registerEvents(component, instance, eventMap) {
           google.maps.event.addListener(
             instance,
             googleEventName,
-            component.props[onEventName]
+            function(mouseEvent){
+              component.props[onEventName](mouseEvent)
+            }
           )
         )
       }


### PR DESCRIPTION
Event listeners registerer `registerEvents`, as it stands, swallows the `PolyMouseEvent` returned by `addEventListener` as documented [here](https://developers.google.com/maps/documentation/javascript/reference/polygon#Polyline.click). This PR change will pass the event to the callback function so that consumer can get access to PolyMouseEvent and and therefore have access to the `latLng` properties of the event. For example, one may want to position an `infoWindow` on the event position when polygon event occurs.

Thank you :)