### PR TITLE
fix(ClassDefinition): Change url of google maps api reference

### DIFF
--- a/src/tx/ClassDefinition.js
+++ b/src/tx/ClassDefinition.js
@@ -9,7 +9,7 @@ const fetch = makeFetchHappen.defaults({
 const KlassName = process.argv[2]
 
 fetch(
-  "https://developers.google.com/maps/documentation/javascript/3.exp/reference"
+  "https://web.archive.org/web/20180503052259/https://developers.google.com/maps/documentation/javascript/reference/3/"
 )
   .then(it => it.text())
   .then(it => cheerio.load(it))

--- a/src/tx/ClassDefinition.js
+++ b/src/tx/ClassDefinition.js
@@ -33,7 +33,7 @@ function contentToJS(KlassName, $, $content) {
   const $constructorTable = $content.find(
     `[summary="class ${KlassName} - Constructor"]`
   )
-  const [, constructorArgs] = $constructorTable
+  const constructorArgs = $constructorTable
     .find(`tr > td > code`)
     .text()
     .match(/\S+\((.*)\)/)


### PR DESCRIPTION
Google have changed the design of their reference page, thus breaking the build:src task (uses scraping to get class methods/events)

This PR changes the URL to the last one I could find before the design change that breaks the task