### PR TITLE
fix(docs/configuration): fix syntax errors (#902)

### DIFF
--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -114,7 +114,7 @@ const MyMapComponent = compose(
   >
     {props.isMarkerShown && <Marker position={{ lat: -34.397, lng: 150.644 }} />}
   </GoogleMap>
-))
+)
 
 <MyMapComponent isMarkerShown />
 ```
@@ -146,7 +146,7 @@ const MyMapComponent = compose(
   >
     {props.isMarkerShown && <Marker position={{ lat: -34.397, lng: 150.644 }} onClick={props.onMarkerClick} />}
   </GoogleMap>
-))
+)
 
 class MyFancyComponent extends React.PureComponent {
   state = {


### PR DESCRIPTION
Fixes 2 syntax errors in the `configuration.md` docs page.
