### PR TITLE
fix app crash because google is undefined in a PWA if the user is offline and cache is disabled.

### DIFF
--- a/src/withGoogleMap.jsx
+++ b/src/withGoogleMap.jsx
@@ -49,12 +49,15 @@ export function withGoogleMap(BaseComponent) {
       if (this.state.map || node === null) {
         return
       }
-      warning(
-        `undefined` !== typeof google,
-        `Make sure you've put a <script> tag in your <head> element to load Google Maps JavaScript API v3.
+      if (`undefined` === typeof google) {
+        warning(
+          `undefined` !== typeof google,
+          `Make sure you've put a <script> tag in your <head> element to load Google Maps JavaScript API v3.
  If you're looking for built-in support to load it for you, use the "async/ScriptjsLoader" instead.
  See https://github.com/tomchentw/react-google-maps/pull/168`
-      )
+        )
+        return
+      }
       // https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map
       const map = new google.maps.Map(node)
       this.setState({ map })


### PR DESCRIPTION
When i open my app in offline mode if [https://maps.googleapis.com/maps/api/js]() is not available in browser cache like disk cache the app craches because google is not defined.
You can see the error here [https://xmokax.github.io/map-app/]() by following these steps:

1. open the app and wait for service worker to install and finish precaching assets.
2. reload the page and then go to the network tab in the developer tools and choose offline then reload the app. The app will work because google maps script will be served from disk cache.
3. go to network tab in developer tools and choose both offline and disable cache too then reload the page the app will crash because google is not defined.

This PR to fixes this problem.