### PR TITLE
chore(package.json): fix peer dependency with react@17

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
     "@types/googlemaps": "^3.0.0",
     "@types/markerclustererplus": "^2.1.29",
     "@types/react": "^15.0.0 || ^16.0.0",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "@types/googlemaps": "^3.29.2",


### PR DESCRIPTION
I getting this error using npm@7 and I fixed your package, because your npm works properly with react@17

```
npm ERR! Found: react@17.0.1
npm ERR! node_modules/react
npm ERR!   react@"17.0.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^15.0.0 || ^16.0.0" from react-google-maps@9.4.5
npm ERR! node_modules/react-google-maps
npm ERR!   react-google-maps@"9.4.5" from the root project
```