### PR TITLE
fix: Use React.createElement instead of deprecated createFactory

### DIFF
--- a/src/utils/CreateReactFactoryHelper.js
+++ b/src/utils/CreateReactFactoryHelper.js
@@ -1,0 +1,3 @@
+export function createFactory(type) {
+  React.createElement.bind(null, type)
+}

--- a/src/withGoogleMap.jsx
+++ b/src/withGoogleMap.jsx
@@ -6,9 +6,10 @@ import { getDisplayName } from "recompose"
 import PropTypes from "prop-types"
 import React from "react"
 import { MAP } from "./constants"
+import { createFactory } from "./utils/CreateReactFactoryHelper"
 
 export function withGoogleMap(BaseComponent) {
-  const factory = React.createFactory(BaseComponent)
+  const factory = createFactory(BaseComponent)
 
   class Container extends React.PureComponent {
     static displayName = `withGoogleMap(${getDisplayName(BaseComponent)})`

--- a/src/withScriptjs.jsx
+++ b/src/withScriptjs.jsx
@@ -4,13 +4,14 @@ import canUseDOM from "can-use-dom"
 import { getDisplayName } from "recompose"
 import PropTypes from "prop-types"
 import React from "react"
+import { createFactory } from "./utils/CreateReactFactoryHelper"
 
 const LOADING_STATE_NONE = `NONE`
 const LOADING_STATE_BEGIN = `BEGIN`
 const LOADING_STATE_LOADED = `LOADED`
 
 export function withScriptjs(BaseComponent) {
-  const factory = React.createFactory(BaseComponent)
+  const factory = createFactory(BaseComponent)
 
   class Container extends React.PureComponent {
     static displayName = `withScriptjs(${getDisplayName(BaseComponent)})`


### PR DESCRIPTION
I'm using this package with React 17, and I'm getting warnings related to the usage of `createFactory` since it was [deprecated](https://reactjs.org/blog/2020/02/26/react-v16.13.0.html#deprecating-reactcreatefactory) in React 16.13.0

This PR fixes the issue by creating a helper method that wraps the functionality of `createElement` under `createFactory`
